### PR TITLE
Define grid areas for view panes

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -16,7 +16,21 @@
   small, .muted{color:#b7b7b7}
   button,input,select{font:inherit}
   .app{display:grid;grid-template-columns:1fr 360px;gap:8px;height:100%;padding:8px}
-  .views{display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:6px;min-width:0;min-height:0}
+  .views{
+    display:grid;
+    grid-template-columns:1fr 1fr;
+    grid-template-rows:1fr 1fr;
+    grid-template-areas:
+      "front 3d"
+      "side plan";
+    gap:6px;
+    min-width:0;
+    min-height:0
+  }
+  #pane-front{grid-area:front}
+  #pane-3d{grid-area:3d}
+  #pane-side{grid-area:side}
+  #pane-plan{grid-area:plan}
   .pane{position:relative;background:var(--panel);border:1px solid #222;border-radius:6px;min-width:0;min-height:0;overflow:hidden}
   .pane canvas{width:100%;height:100%;display:block}
   .hud{position:absolute;left:8px;top:8px;background:#0008;border-radius:4px;padding:4px 8px;font-size:12px}


### PR DESCRIPTION
## Summary
- Explicitly define CSS grid areas for the four view panes.
- Move the 3D view to the top-right position and assign grid areas for each pane to ensure consistent layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc156b3888321a7be6d8497a04b64