### PR TITLE
Fix HTML closing tags in rail-bin-builder

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -228,7 +228,6 @@
       </div>
     </div>
   </div>
-</body>
 <script>
 /* =====================
    Utilities & palette
@@ -739,5 +738,5 @@ window.addEventListener('DOMContentLoaded', init);
   updateAlerts();
 })();
 </script>
-</html>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- fix invalid HTML structure by moving script inside `<body>` and removing duplicate `</html>` tag

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689dc0501f588321a1b60d09f0ceea98