### PR TITLE
Start in single view on narrow screens

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -649,6 +649,7 @@ function bindInputs(){
     }
     renderAll();
   }
+  window.setView = setView;
   document.getElementById('vmQuad').onclick=()=>setView('quad');
   document.getElementById('vm3d').onclick =()=>setView('3d');
   document.getElementById('vmPlan').onclick=()=>setView('plan');
@@ -685,7 +686,9 @@ function renderAll(){
 function init(){
   bind3DInteractions();
   bindInputs();
-  renderAll();
+  const isNarrow = window.matchMedia('(max-width: 600px)').matches;
+  if(isNarrow) setView('3d');
+  else renderAll();
 }
 window.addEventListener('DOMContentLoaded', init);
 </script>


### PR DESCRIPTION
## Summary
- Expose `setView` globally for use during startup
- Detect narrow screens on init and switch to single 3D view to avoid quad mode on phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dcfd3a6f08321bfe536ef78e7a71d