### PR TITLE
Add bin overhang limit and alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 | F-014 | Cut List toggle (show/hide) | ✅ | toggleCutlist |
 | F-015 | Single geometry source for all views | ✅ | buildModel(S) → M.boxes |
 | F-016 | Bottom row has/no rails (option) | ✅ | bottomRowRails |
-| F-017 | Per-row overhang depth (bin can exceed carcass) | ✅ | overhang per row → dHere |
+| F-017 | Per-row overhang depth (bin can exceed carcass) | ✅ | overhang per row → dHere (clamped by MAX_OVERHANG) |
 | F-018 | Per-row gap above (bin clearance) | ✅ | gap per row |
 | F-019 | Auto height formula (caps + lintels + rows) | ✅ | autoHeightFromRows() |
 | F-020 | Plan opening labels: ✓ within ±0.5 mm, else Δ red | ✅ | In renderPlan() |
@@ -47,7 +47,7 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 | L-005 | Rails per opening | edges: [x, x+w−post]; centered: [x+(w−post)/2] | railXPositions() |
 | L-006 | Rail depth clamp | usable = min(runnerDepth, depth) | Build & all views |
 | L-007 | Bin sitting | yTop = level + post − binLip | Build (then views read M) |
-| L-008 | Bin depth per row | dHere = min(D + max(0, over), D + over) | allows overhang |
+| L-008 | Bin depth per row | dHere = clamp(D + over, 0, D + MAX_OVERHANG) | limits overhang |
 | L-009 | Supports Y | top: clamp(post + topDrop, post, H−2·post); bottom: clamp(H−2·post−bottomLift, …) | Avoids lintel overlap |
 | L-010 | Rear frame | Mirror posts/lintels at z = D − post | Toggle |
 | L-011 | Apply opening | Rewrite patternText posts-kept, channels→suggested | Button handler |

--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -246,6 +246,7 @@
 ===================== */
 const clamp=(v,a,b)=>Math.max(a,Math.min(b,Number(v??0)));
 const mm=v=>Number(v||0);
+const MAX_OVERHANG = 300; // max extra depth beyond carcass
 const COLORS={ post:'#f5dfe0', lintel:'#e8e8e8', rail:'#c9e1ff', support:'#f6c16c', bin:'rgba(255,179,179,.65)', line:'#cfcfcf', dash:'#d8a7ad' };
 COLORS.supportBatten = COLORS.support;
 function rgba(hex,a){const c=hex.replace('#','');const r=parseInt(c.slice(0,2),16),g=parseInt(c.slice(2,4),16),b=parseInt(c.slice(4,6),16);return `rgba(${r},${g},${b},${a})`;}
@@ -356,6 +357,7 @@ function buildModel(){
   const P=S.post, ch=channels(), L=computeLevels(), W=segments().reduce((a,b)=>a+b,0);
   const H=S.autoHeight?autoHeightFromRows():S.height, D=S.depth, R=Math.min(S.runnerDepth, S.depth);
   const M={W,H,D,P,channels:ch,levels:L,boxes:[]};
+  let binDepthClamped=false;
 
   // Posts (front)
   let x=0; for(const s of segments()){ if(s===P) M.boxes.push({type:'post',x,y:0,z:0,w:P,h:H,d:P}); x+=s; }
@@ -400,12 +402,16 @@ function buildModel(){
         const binH=mm(row.height ?? S.binHeightDefault);
         const over=mm(row.overhang ?? 0); // per-row overhang
         const gap=mm(row.gap ?? 0);        // per-row gap (clearance above)
-        const dHere= Math.min(D + Math.max(0,over), D + over); // allow overhang
+        const dReq = D + over;
+        const dHere = clamp(dReq, 0, D + MAX_OVERHANG);
+        if(dHere !== dReq) binDepthClamped = true;
         const yTop = Math.max(0, y + P - lip); // seat by lip
         M.boxes.push({type:'bin',x:bx,y:yTop,z:0,w:overall,h:binH,d:dHere, gap});
       }
     });
   });
+
+  M.binDepthClamped = binDepthClamped;
 
   // Bounds (frame components only; exclude bins so rotation pivots at frame center)
   const bMin=[Infinity,Infinity,Infinity];
@@ -858,10 +864,12 @@ window.addEventListener('DOMContentLoaded', init);
     if (off.length) msgs.push(`${off.length} opening(s) differ from target by ≥ 0.5 mm.`);
     // 3) Runner depth clamp info
     if (S.runnerDepth > S.depth) msgs.push(`Runner depth ${S.runnerDepth} clamped to carcass depth ${S.depth}.`);
-    // 4) Bottom rails
+    // 4) Bin depth clamp info
+    if (M.binDepthClamped) msgs.push(`Bin depth clamped to 0–${S.depth + MAX_OVERHANG} mm.`);
+    // 5) Bottom rails
     if (!S.bottomRowRails) msgs.push('Bottom row rails: OFF (first level has no rails).');
 
-    // 5) Timber overlap
+    // 6) Timber overlap
     const timber = M.boxes.filter(b => ['post','lintel','rail','support'].includes(b.type));
     outer: for(let i=0;i<timber.length;i++){
       for(let j=i+1;j<timber.length;j++){


### PR DESCRIPTION
## Summary
- Add `MAX_OVERHANG` constant and use it to clamp bin depth per row
- Flag when bin depth is clamped and surface an alert in the UI
- Document new bin-depth clamping logic in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a27af058d08321ae1fd1331b59aa5b