### PR TITLE
Align bin seating with rail tops

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 | F-003 | Four views always render (3D, Plan, Front, Side) | ✅ | Each reads M from buildModel() |
 | F-004 | Two rails per opening at edges (or centered) | ✅ | railXPositions() (edges/centered) |
 | F-005 | Bin helper: opening = body + 2*lip + slack; Apply rewrites pattern | ✅ | Button handler rewrites patternText |
-| F-006 | Bins sit by lip: binTop = level + post − binLip | ✅ | Used in 3D & Side |
+| F-006 | Bins sit by lip: binTop = level − binLip | ✅ | Used in 3D & Side |
 | F-007 | Clamp rail depth usable = min(runnerDepth, depth) | ✅ | All views + Cut List |
 | F-008 | Rear frame (back posts + lintels) & counts | ✅ | Toggle rearFrame |
 | F-009 | Supports: top/bottom with drop/lift & orientation (X/Z) | ✅ | No overlap with lintels |
@@ -43,10 +43,10 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 | L-001 | Parse inputs | Text list → mm ceil | parseList() |
 | L-002 | Normalize pattern | Ensure [post, open…, post], collapse duplicate posts | normalizeSegments() |
 | L-003 | Channels | Keep segments > post as channels {x,w} | channels() |
-| L-004 | Levels (rows) | y += height[i] + post (+ gap); start at post + bottomClear | computeLevels() |
+| L-004 | Levels (rail tops) | y += height[i] + gap + post; start at 2·post + bottomClear | computeLevels() |
 | L-005 | Rails per opening | edges: [x, x+w−post]; centered: [x+(w−post)/2] | railXPositions() |
 | L-006 | Rail depth clamp | usable = min(runnerDepth, depth) | Build & all views |
-| L-007 | Bin sitting | yTop = level + post − binLip | Build (then views read M) |
+| L-007 | Bin sitting | yTop = level − binLip | Build (then views read M) |
 | L-008 | Bin depth per row | dHere = min(D + max(0, over), D + over) | allows overhang |
 | L-009 | Supports Y | top: clamp(post + topDrop, post, H−2·post); bottom: clamp(H−2·post−bottomLift, …) | Avoids lintel overlap |
 | L-010 | Rear frame | Mirror posts/lintels at z = D − post | Toggle |

--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -330,12 +330,12 @@ function railXPositions(ch){
 }
 function computeLevels(){
   const P=S.post;
-  let y=P + mm(S.bottomClear);
+  let y=2*P + mm(S.bottomClear); // track rail tops
   const out=[];
   for(const r of S.rows){
-    out.push(clamp(y,0,(S.autoHeight?1e9:S.height)-P));
-    // Height of row + lintel + gap above that row
-    y += mm(r.height) + P + mm(r.gap);
+    out.push(clamp(y,0,(S.autoHeight?1e9:S.height)));
+    // Height of row + gap above that row + lintel thickness
+    y += mm(r.height) + mm(r.gap) + P;
   }
   return out;
 }
@@ -390,7 +390,7 @@ function buildModel(){
     const xs=railXPositions(c);
     L.forEach((y,idx)=>{
       const allowBottom = (idx!==0 || S.bottomRowRails);
-      if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
+      if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y:y-P,z:0,w:P,h:P,d:R}));
       if(S.showBins && allowBottom){
         const row=S.rows[idx]||{};
         const bodyW=Math.min(mm(S.binBody), c.w-2);
@@ -401,7 +401,7 @@ function buildModel(){
         const over=mm(row.overhang ?? 0); // per-row overhang
         const gap=mm(row.gap ?? 0);        // per-row gap (clearance above)
         const dHere= Math.min(D + Math.max(0,over), D + over); // allow overhang
-        const yTop = Math.max(0, y + P - lip); // seat by lip
+        const yTop = Math.max(0, y - lip); // seat by lip
         M.boxes.push({type:'bin',x:bx,y:yTop,z:0,w:overall,h:binH,d:dHere, gap});
       }
     });
@@ -807,6 +807,9 @@ function runTests(M){
   T.push({name:'post count', pass:(()=>{const expected=segments().filter(s=>s===S.post).length*(S.rearFrame?2:1); return M.boxes.filter(b=>b.type==='post').length===expected;})()});
   T.push({name:'lintel count', pass:(()=>{const expected=S.rearFrame?4:2; return M.boxes.filter(b=>b.type==='lintel').length===expected;})()});
   T.push({name:'rail count', pass:(()=>{const perOpening=(S.railMode==='centered'?1:2); const levelCount=S.rows.length-(S.bottomRowRails?0:1); const expected=channels().length*levelCount*perOpening; return M.boxes.filter(b=>b.type==='rail').length===expected;})()});
+
+  // bin position
+  T.push({name:'bins seat on rails', pass:(()=>{const rails=M.boxes.filter(b=>b.type==='rail'); const lip=mm(S.binLip); return M.boxes.filter(b=>b.type==='bin').every(bin=>rails.some(r=>eq(bin.y+lip, r.y+r.h)));})()});
 
   const el=document.getElementById('tests');
   if(el) el.innerHTML=T.map(t=>`<div class="${t.pass?'ok':'ng'}">${t.pass?'✓':'✗'} ${t.name}</div>`).join('');


### PR DESCRIPTION
## Summary
- Treat level values as the top of each rail
- Place rails at `y - P` and seat bins using `yTop = y - lip`
- Add runtime check ensuring bin lips rest on rail tops and document new formulas

## Testing
- `node - <<'NODE'
const fs=require('fs'), vm=require('vm');
const html=fs.readFileSync('rail-bin-builder.html','utf8');
const js=html.match(/<script>([\s\S]*?)<\/script>/)[1];
let testHTML='';
const document={getElementById:()=>({set innerHTML(v){testHTML=v;}})};
const context={console, window:{addEventListener:()=>{}}, document};
vm.runInNewContext(js, context);
vm.runInContext('M=buildModel();', context);
vm.runInContext('runTests(M);', context);
console.log(testHTML);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a27aeb61b08321804a79d84f04c2fc