### PR TITLE
refactor: modularize views and model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Timber Size</title>
+<style>
+  body{margin:0;display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);} 
+  canvas{width:100%;height:100%;background:#111;}
+</style>
+</head>
+<body>
+<canvas id="front"></canvas>
+<canvas id="view3d"></canvas>
+<canvas id="side"></canvas>
+<canvas id="plan"></canvas>
+<script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,16 @@
+import {S} from './state.js';
+import {buildModel} from './model.js';
+import {renderFront} from './views/front.js';
+import {renderSide} from './views/side.js';
+import {renderPlan} from './views/plan.js';
+import {render3d} from './views/view3d.js';
+
+function init() {
+  const model = buildModel(S);
+  renderFront(document.getElementById('front'), model);
+  renderSide(document.getElementById('side'), model);
+  renderPlan(document.getElementById('plan'), model);
+  render3d(document.getElementById('view3d'), model);
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,13 @@
+export function buildModel(S) {
+  const boxes = [];
+  const {width, height, depth, post} = S;
+  // Four corner posts
+  boxes.push({x:0, y:0, z:0, w:post, h:height, d:post});
+  boxes.push({x:width-post, y:0, z:0, w:post, h:height, d:post});
+  boxes.push({x:0, y:0, z:depth-post, w:post, h:height, d:post});
+  boxes.push({x:width-post, y:0, z:depth-post, w:post, h:height, d:post});
+  return {
+    boxes,
+    bounds: {width, height, depth}
+  };
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,6 @@
+export const S = {
+  width: 1000,
+  height: 1000,
+  depth: 600,
+  post: 50
+};

--- a/src/utils/camera3d.js
+++ b/src/utils/camera3d.js
@@ -1,0 +1,17 @@
+export function makeCamera(bounds) {
+  const distance = Math.max(bounds.width, bounds.depth) * 2;
+  return {
+    distance,
+    cx: bounds.width / 2,
+    cy: bounds.height / 2
+  };
+}
+
+export function project(point, camera) {
+  const {x, y, z} = point;
+  const scale = camera.distance / (camera.distance + z);
+  return {
+    x: camera.cx + x * scale,
+    y: camera.cy - y * scale
+  };
+}

--- a/src/utils/draw2d.js
+++ b/src/utils/draw2d.js
@@ -1,0 +1,16 @@
+export function drawRect(ctx, x, y, w, h, color = '#fff') {
+  ctx.strokeStyle = color;
+  ctx.strokeRect(x, y, w, h);
+}
+
+export function drawPolygon(ctx, points, color = '#fff') {
+  if (points.length === 0) return;
+  ctx.beginPath();
+  ctx.strokeStyle = color;
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i++) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.closePath();
+  ctx.stroke();
+}

--- a/src/utils/fit.js
+++ b/src/utils/fit.js
@@ -1,0 +1,10 @@
+export function fitCanvas(canvas, bounds) {
+  const ctx = canvas.getContext('2d');
+  canvas.width = canvas.clientWidth;
+  canvas.height = canvas.clientHeight;
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const scale = Math.min(canvas.width / bounds.width, canvas.height / bounds.height);
+  ctx.setTransform(scale, 0, 0, -scale, 0, canvas.height);
+  return ctx;
+}

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,0 +1,9 @@
+import {drawRect} from '../utils/draw2d.js';
+import {fitCanvas} from '../utils/fit.js';
+
+export function renderFront(canvas, model) {
+  const ctx = fitCanvas(canvas, {width: model.bounds.width, height: model.bounds.height});
+  model.boxes.forEach(box => {
+    drawRect(ctx, box.x, box.y, box.w, box.h);
+  });
+}

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,0 +1,9 @@
+import {drawRect} from '../utils/draw2d.js';
+import {fitCanvas} from '../utils/fit.js';
+
+export function renderPlan(canvas, model) {
+  const ctx = fitCanvas(canvas, {width: model.bounds.width, height: model.bounds.depth});
+  model.boxes.forEach(box => {
+    drawRect(ctx, box.x, box.z, box.w, box.d);
+  });
+}

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,0 +1,9 @@
+import {drawRect} from '../utils/draw2d.js';
+import {fitCanvas} from '../utils/fit.js';
+
+export function renderSide(canvas, model) {
+  const ctx = fitCanvas(canvas, {width: model.bounds.depth, height: model.bounds.height});
+  model.boxes.forEach(box => {
+    drawRect(ctx, box.z, box.y, box.d, box.h);
+  });
+}

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,0 +1,34 @@
+import {drawPolygon} from '../utils/draw2d.js';
+import {makeCamera, project} from '../utils/camera3d.js';
+
+export function render3d(canvas, model) {
+  const ctx = canvas.getContext('2d');
+  canvas.width = canvas.clientWidth;
+  canvas.height = canvas.clientHeight;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cam = makeCamera(model.bounds);
+  cam.cx = canvas.width / 2;
+  cam.cy = canvas.height * 0.8;
+  model.boxes.forEach(box => {
+    const pts = [
+      {x: box.x, y: box.y, z: box.z},
+      {x: box.x + box.w, y: box.y, z: box.z},
+      {x: box.x + box.w, y: box.y + box.h, z: box.z},
+      {x: box.x, y: box.y + box.h, z: box.z},
+      {x: box.x, y: box.y, z: box.z + box.d},
+      {x: box.x + box.w, y: box.y, z: box.z + box.d},
+      {x: box.x + box.w, y: box.y + box.h, z: box.z + box.d},
+      {x: box.x, y: box.y + box.h, z: box.z + box.d}
+    ];
+    const p = pts.map(pt => project(pt, cam));
+    drawPolygon(ctx, [p[0], p[1], p[2], p[3]]);
+    drawPolygon(ctx, [p[4], p[5], p[6], p[7]]);
+    for (let i = 0; i < 4; i++) {
+      ctx.beginPath();
+      ctx.moveTo(p[i].x, p[i].y);
+      ctx.lineTo(p[i + 4].x, p[i + 4].y);
+      ctx.strokeStyle = '#fff';
+      ctx.stroke();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- split state, model building, and view projections into separate modules
- add utility helpers for 2D drawing, 3D camera projection, and canvas fitting
- load modular entry point through `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a27d9c6f68832199228bbab57f98b8