### PR TITLE
chore: add build and packaging scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build single HTML and release
+
+on:
+  push:
+    tags:
+      - "v*"        # e.g., v0.1.0
+  workflow_dispatch: {}
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci || npm i
+
+      - name: Build bundle
+        run: npm run build
+
+      - name: Pack single HTML
+        run: npm run pack
+
+      - name: Upload artifact (for this run)
+        uses: actions/upload-artifact@v4
+        with:
+          name: app.single.html
+          path: dist/app.single.html
+
+      - name: Create GitHub Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/app.single.html
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/index.html
+++ b/index.html
@@ -1,18 +1,19 @@
 <!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<title>Timber Size</title>
-<style>
-  body{margin:0;display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);} 
-  canvas{width:100%;height:100%;background:#111;}
-</style>
-</head>
-<body>
-<canvas id="front"></canvas>
-<canvas id="view3d"></canvas>
-<canvas id="side"></canvas>
-<canvas id="plan"></canvas>
-<script type="module" src="src/main.js"></script>
-</body>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rail + Bin Builder</title>
+
+    <!-- PACK:INLINE_CSS -->
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <canvas id="front"></canvas>
+    <canvas id="side"></canvas>
+    <canvas id="plan"></canvas>
+    <canvas id="three"></canvas>
+
+    <script type="module" src="./src/main.js"></script>
+    <!-- PACK:INLINE_JS -->
+  </body>
 </html>

--- a/pack.mjs
+++ b/pack.mjs
@@ -1,0 +1,33 @@
+import fs from "fs/promises";
+import path from "path";
+
+const read = (p) => fs.readFile(p, "utf8");
+
+await fs.mkdir("dist", { recursive: true });
+
+const [html, css, js] = await Promise.all([
+  read("index.html"),
+  read("styles.css").catch(() => ""),
+  read("dist/bundle.js")
+]);
+
+let single = html;
+
+// Inline CSS at the marker; if marker missing, replace the <link> line.
+if (single.includes("PACK:INLINE_CSS")) {
+  single = single.replace("<!-- PACK:INLINE_CSS -->", `<style>${css}</style>`);
+} else {
+  single = single.replace(
+    /<link[^>]+styles\.css[^>]*>/,
+    `<style>${css}</style>`
+  );
+}
+
+// Inline JS at the marker; also remove the module tag that loads src/main.js
+single = single
+  .replace(/<script[^>]+type="module"[^>]*src="\.\/src\/main\.js"[^>]*><\/script>/, "")
+  .replace("<!-- PACK:INLINE_JS -->", `<script>${js}</script>`);
+
+const out = path.join("dist", "app.single.html");
+await fs.writeFile(out, single, "utf8");
+console.log("✅ Wrote", out);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rail-bin-builder",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/main.js --bundle --format=iife --minify --outfile=dist/bundle.js",
+    "pack": "node pack.mjs"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ function init() {
   renderFront(document.getElementById('front'), model);
   renderSide(document.getElementById('side'), model);
   renderPlan(document.getElementById('plan'), model);
-  render3d(document.getElementById('view3d'), model);
+  render3d(document.getElementById('three'), model);
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,2 @@
+body{margin:0;display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);}
+canvas{width:100%;height:100%;background:#111;}


### PR DESCRIPTION
## Summary
- add npm-based build and pack scripts using esbuild
- move styles to separate file and update entry HTML
- provide workflow to build and attach single-file release

## Testing
- `npm i` *(fails: 403 Forbidden - GET https://registry.npmjs.org/esbuild)*
- `npm run build` *(fails: esbuild: not found)*
- `npm run pack` *(fails: ENOENT: no such file or directory, open 'dist/bundle.js')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a27f1d4c108321a44c8b4cb626b5d1