### PR TITLE
Add reactive state manager and dimension controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,22 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
+    <form id="controls">
+      <div>
+        <label>Width <input type="number" id="width" /></label>
+        <label>Height <input type="number" id="height" /></label>
+        <label>Depth <input type="number" id="depth" /></label>
+        <label>Post <input type="number" id="post" /></label>
+        <label>Pattern <input type="text" id="pattern" /></label>
+      </div>
+      <div>
+        <label><input type="checkbox" id="showFront" checked /> Front</label>
+        <label><input type="checkbox" id="showSide" checked /> Side</label>
+        <label><input type="checkbox" id="showPlan" checked /> Plan</label>
+        <label><input type="checkbox" id="showThree" checked /> 3D</label>
+      </div>
+    </form>
+
     <canvas id="front"></canvas>
     <canvas id="side"></canvas>
     <canvas id="plan"></canvas>

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,73 @@
-import {S} from './state.js';
+import {
+  getState,
+  subscribe,
+  setWidth,
+  setHeight,
+  setDepth,
+  setPost,
+  setPattern,
+  setFeature
+} from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
 import {render3d} from './views/view3d.js';
 
+const canvases = {};
+
+function renderAll() {
+  const state = getState();
+  const model = buildModel(state);
+
+  canvases.front.style.display = state.features.front ? '' : 'none';
+  canvases.side.style.display = state.features.side ? '' : 'none';
+  canvases.plan.style.display = state.features.plan ? '' : 'none';
+  canvases.three.style.display = state.features.three ? '' : 'none';
+
+  if (state.features.front) {
+    renderFront(canvases.front, model);
+  }
+  if (state.features.side) {
+    renderSide(canvases.side, model);
+  }
+  if (state.features.plan) {
+    renderPlan(canvases.plan, model);
+  }
+  if (state.features.three) {
+    render3d(canvases.three, model);
+  }
+}
+
 function init() {
-  const model = buildModel(S);
-  renderFront(document.getElementById('front'), model);
-  renderSide(document.getElementById('side'), model);
-  renderPlan(document.getElementById('plan'), model);
-  render3d(document.getElementById('three'), model);
+  canvases.front = document.getElementById('front');
+  canvases.side = document.getElementById('side');
+  canvases.plan = document.getElementById('plan');
+  canvases.three = document.getElementById('three');
+
+  const state = getState();
+
+  document.getElementById('width').value = state.width;
+  document.getElementById('height').value = state.height;
+  document.getElementById('depth').value = state.depth;
+  document.getElementById('post').value = state.post;
+  document.getElementById('pattern').value = state.pattern;
+  document.getElementById('showFront').checked = state.features.front;
+  document.getElementById('showSide').checked = state.features.side;
+  document.getElementById('showPlan').checked = state.features.plan;
+  document.getElementById('showThree').checked = state.features.three;
+
+  document.getElementById('width').addEventListener('input', e => setWidth(e.target.value));
+  document.getElementById('height').addEventListener('input', e => setHeight(e.target.value));
+  document.getElementById('depth').addEventListener('input', e => setDepth(e.target.value));
+  document.getElementById('post').addEventListener('input', e => setPost(e.target.value));
+  document.getElementById('pattern').addEventListener('input', e => setPattern(e.target.value));
+  document.getElementById('showFront').addEventListener('change', e => setFeature('front', e.target.checked));
+  document.getElementById('showSide').addEventListener('change', e => setFeature('side', e.target.checked));
+  document.getElementById('showPlan').addEventListener('change', e => setFeature('plan', e.target.checked));
+  document.getElementById('showThree').addEventListener('change', e => setFeature('three', e.target.checked));
+
+  subscribe(renderAll);
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,67 @@
-export const S = {
+const state = {
   width: 1000,
   height: 1000,
   depth: 600,
-  post: 50
+  post: 50,
+  pattern: '',
+  features: {
+    front: true,
+    side: true,
+    plan: true,
+    three: true
+  }
 };
+
+const listeners = new Set();
+
+function notify() {
+  const snapshot = getState();
+  listeners.forEach(fn => fn(snapshot));
+}
+
+export function getState() {
+  return {
+    width: state.width,
+    height: state.height,
+    depth: state.depth,
+    post: state.post,
+    pattern: state.pattern,
+    features: { ...state.features }
+  };
+}
+
+export function subscribe(fn) {
+  listeners.add(fn);
+  fn(getState());
+  return () => listeners.delete(fn);
+}
+
+export function setWidth(v) {
+  state.width = Number(v);
+  notify();
+}
+
+export function setHeight(v) {
+  state.height = Number(v);
+  notify();
+}
+
+export function setDepth(v) {
+  state.depth = Number(v);
+  notify();
+}
+
+export function setPost(v) {
+  state.post = Number(v);
+  notify();
+}
+
+export function setPattern(v) {
+  state.pattern = v;
+  notify();
+}
+
+export function setFeature(name, on) {
+  state.features[name] = !!on;
+  notify();
+}


### PR DESCRIPTION
## Summary
- Introduce reactive state manager with setters for dimensions, pattern text, and feature toggles
- Add form UI for editing dimensions, pattern, and view toggles
- Re-render canvases when state updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adc474f2c4832199b30f50b3657a39