### PR TITLE
Add basic runtime tests and npm test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 2. Open `index.html` in a modern web browser.
 3. Enter your storage pattern and dimensions. The 3D, plan, front, and side views update automatically, and cut lists are generated live.
 4. (Optional) Run in-browser checks by calling `runTests()` from the developer console.
+5. Run the same checks in Node with `npm test`.
 
 ## Version Change Log
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/main.js --bundle --format=iife --minify --outfile=dist/bundle.js",
-    "pack": "node pack.mjs"
+    "pack": "node pack.mjs",
+    "test": "node src/tests/index.js"
   },
   "devDependencies": {
     "esbuild": "^0.24.0"

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
 import {render3d} from './views/view3d.js';
+import './tests/index.js';
 
 function init() {
   const model = buildModel(S);

--- a/src/tests/clamp.test.js
+++ b/src/tests/clamp.test.js
@@ -1,0 +1,9 @@
+import {clamp} from '../utils/clamp.js';
+
+export function clampTests() {
+  return [
+    {name: 'clamp: upper bound', pass: clamp(10, 0, 5) === 5},
+    {name: 'clamp: lower bound', pass: clamp(-1, 0, 5) === 0},
+    {name: 'clamp: inside range', pass: clamp(3, 0, 5) === 3}
+  ];
+}

--- a/src/tests/counts.test.js
+++ b/src/tests/counts.test.js
@@ -1,0 +1,9 @@
+import {buildModel} from '../model.js';
+import {S} from '../state.js';
+
+export function countTests() {
+  const model = buildModel(S);
+  return [
+    {name: 'count: posts', pass: model.boxes.length === 4}
+  ];
+}

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -1,0 +1,19 @@
+import {parserTests} from './parser.test.js';
+import {clampTests} from './clamp.test.js';
+import {countTests} from './counts.test.js';
+import {pathToFileURL} from 'url';
+
+export function runTests() {
+  const results = [...parserTests(), ...clampTests(), ...countTests()];
+  results.forEach(t => console[t.pass ? 'log' : 'error'](`${t.pass ? '✓' : '✗'} ${t.name}`));
+  return results;
+}
+
+if (typeof window !== 'undefined') {
+  window.runTests = runTests;
+}
+
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  runTests();
+}

--- a/src/tests/parser.test.js
+++ b/src/tests/parser.test.js
@@ -1,0 +1,9 @@
+import {parseList} from '../utils/parse.js';
+
+export function parserTests() {
+  const fallback = [40, 283, 40];
+  return [
+    {name: 'parser: mm suffix', pass: parseList('40mm,283,40').join(',') === '40,283,40'},
+    {name: 'parser: fallback', pass: parseList('x,y', fallback).join(',') === fallback.join(',')}
+  ];
+}

--- a/src/utils/clamp.js
+++ b/src/utils/clamp.js
@@ -1,0 +1,3 @@
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,0 +1,12 @@
+export function parseList(text, fallback = []) {
+  const parts = String(text).split(',').map(p => p.trim()).filter(Boolean);
+  const nums = parts.map(p => {
+    const cleaned = p.toLowerCase().endsWith('mm') ? p.slice(0, -2) : p;
+    const n = Number(cleaned);
+    return Number.isFinite(n) ? Math.ceil(n) : NaN;
+  });
+  if (nums.some(n => Number.isNaN(n))) {
+    return Array.isArray(fallback) ? fallback : String(fallback).split(',').map(s => Number(s)).filter(n => !Number.isNaN(n));
+  }
+  return nums;
+}


### PR DESCRIPTION
## Summary
- add lightweight parser and clamp helpers
- implement parser, clamp, and model count tests with window.runTests
- document and expose `npm test` command

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc46f6f74832189644f0561b6335a