### PR TITLE
build: run build before pack

### DIFF
--- a/pack.mjs
+++ b/pack.mjs
@@ -5,11 +5,19 @@ const read = (p) => fs.readFile(p, "utf8");
 
 await fs.mkdir("dist", { recursive: true });
 
-const [html, css, js] = await Promise.all([
+const bundle = "dist/bundle.js";
+const [html, css] = await Promise.all([
   read("index.html"),
-  read("styles.css").catch(() => ""),
-  read("dist/bundle.js")
+  read("styles.css").catch(() => "")
 ]);
+
+let js;
+try {
+  js = await read(bundle);
+} catch {
+  console.error(`Missing ${bundle}. Did you run 'npm run build'?`);
+  process.exit(1);
+}
 
 let single = html;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/main.js --bundle --format=iife --minify --outfile=dist/bundle.js",
-    "pack": "node pack.mjs"
+    "pack": "npm run build && node pack.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.24.0"


### PR DESCRIPTION
## Summary
- run esbuild automatically when packing and report if bundle.js is missing

## Testing
- `npm test`
- `npm run pack`


------
https://chatgpt.com/codex/tasks/task_e_68adc46e55bc8321aaf2652f9ef218c6