### PR TITLE
Add interactive 3D view controls and view switching

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,14 +3,42 @@ import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
-import {render3d} from './views/view3d.js';
+import {render3d, bind3dControls} from './views/view3d.js';
 
 function init() {
   const model = buildModel(S);
-  renderFront(document.getElementById('front'), model);
-  renderSide(document.getElementById('side'), model);
-  renderPlan(document.getElementById('plan'), model);
-  render3d(document.getElementById('three'), model);
+  const canvases = {
+    front: document.getElementById('front'),
+    side: document.getElementById('side'),
+    plan: document.getElementById('plan'),
+    three: document.getElementById('three')
+  };
+  let viewMode = 'quad';
+
+  function renderAll() {
+    renderFront(canvases.front, model);
+    renderSide(canvases.side, model);
+    renderPlan(canvases.plan, model);
+    render3d(canvases.three, model);
+  }
+
+  function setView(mode) {
+    viewMode = mode;
+    document.body.classList.toggle('single', mode !== 'quad');
+    Object.entries(canvases).forEach(([id, c]) => {
+      c.classList.toggle('active', mode === 'quad' || id === mode);
+    });
+    renderAll();
+  }
+
+  Object.entries(canvases).forEach(([id, c]) => {
+    c.addEventListener('click', () => {
+      setView(viewMode === 'quad' ? id : 'quad');
+    });
+  });
+
+  bind3dControls(canvases.three, renderAll);
+  setView('quad');
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/src/model.js
+++ b/src/model.js
@@ -2,10 +2,10 @@ export function buildModel(S) {
   const boxes = [];
   const {width, height, depth, post} = S;
   // Four corner posts
-  boxes.push({x:0, y:0, z:0, w:post, h:height, d:post});
-  boxes.push({x:width-post, y:0, z:0, w:post, h:height, d:post});
-  boxes.push({x:0, y:0, z:depth-post, w:post, h:height, d:post});
-  boxes.push({x:width-post, y:0, z:depth-post, w:post, h:height, d:post});
+  boxes.push({type:'post', x:0, y:0, z:0, w:post, h:height, d:post});
+  boxes.push({type:'post', x:width-post, y:0, z:0, w:post, h:height, d:post});
+  boxes.push({type:'post', x:0, y:0, z:depth-post, w:post, h:height, d:post});
+  boxes.push({type:'post', x:width-post, y:0, z:depth-post, w:post, h:height, d:post});
   return {
     boxes,
     bounds: {width, height, depth}

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,34 +1,134 @@
-import {drawPolygon} from '../utils/draw2d.js';
-import {makeCamera, project} from '../utils/camera3d.js';
+const COLORS = {
+  post: '#f5dfe0',
+  lintel: '#e8e8e8',
+  rail: '#c9e1ff',
+  support: '#f6c16c',
+  bin: 'rgba(255,179,179,0.65)'
+};
+
+export const state3D = {yaw: 0.5, pitch: 0.3, zoom: 1};
+
+function rgba(hex, alpha = 1) {
+  if (hex.startsWith('rgba')) return hex;
+  const n = parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 255;
+  const g = (n >> 8) & 255;
+  const b = n & 255;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+function makeBoxFaces(x, y, z, w, h, d, color = '#ddd', alpha = 1, edge = '#333') {
+  const v = [
+    [x, y, z],
+    [x + w, y, z],
+    [x + w, y + h, z],
+    [x, y + h, z],
+    [x, y, z + d],
+    [x + w, y, z + d],
+    [x + w, y + h, z + d],
+    [x, y + h, z + d]
+  ];
+  const q = [[0, 1, 2, 3], [4, 5, 6, 7], [0, 4, 7, 3], [1, 5, 6, 2], [0, 1, 5, 4], [3, 2, 6, 7]];
+  return q.map(idx => ({pts: idx.map(i => v[i]), color, alpha, edge}));
+}
+
+function sizeCanvas(cvs) {
+  const dpr = Math.max(1, window.devicePixelRatio || 1);
+  const r = cvs.getBoundingClientRect();
+  const w = Math.max(1, Math.floor(r.width * dpr));
+  const h = Math.max(1, Math.floor(r.height * dpr));
+  if (cvs.width !== w || cvs.height !== h) {
+    cvs.width = w;
+    cvs.height = h;
+    cvs.getContext('2d').setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+}
 
 export function render3d(canvas, model) {
+  sizeCanvas(canvas);
   const ctx = canvas.getContext('2d');
-  canvas.width = canvas.clientWidth;
-  canvas.height = canvas.clientHeight;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const cam = makeCamera(model.bounds);
-  cam.cx = canvas.width / 2;
-  cam.cy = canvas.height * 0.8;
-  model.boxes.forEach(box => {
-    const pts = [
-      {x: box.x, y: box.y, z: box.z},
-      {x: box.x + box.w, y: box.y, z: box.z},
-      {x: box.x + box.w, y: box.y + box.h, z: box.z},
-      {x: box.x, y: box.y + box.h, z: box.z},
-      {x: box.x, y: box.y, z: box.z + box.d},
-      {x: box.x + box.w, y: box.y, z: box.z + box.d},
-      {x: box.x + box.w, y: box.y + box.h, z: box.z + box.d},
-      {x: box.x, y: box.y + box.h, z: box.z + box.d}
-    ];
-    const p = pts.map(pt => project(pt, cam));
-    drawPolygon(ctx, [p[0], p[1], p[2], p[3]]);
-    drawPolygon(ctx, [p[4], p[5], p[6], p[7]]);
-    for (let i = 0; i < 4; i++) {
-      ctx.beginPath();
-      ctx.moveTo(p[i].x, p[i].y);
-      ctx.lineTo(p[i + 4].x, p[i + 4].y);
-      ctx.strokeStyle = '#fff';
-      ctx.stroke();
-    }
+
+  const faces = [];
+  model.boxes.forEach(b => {
+    const color = COLORS[b.type] || '#ddd';
+    const alpha = b.type === 'bin' ? 0.65 : 1;
+    makeBoxFaces(b.x, b.y, b.z, b.w, b.h, b.d, color, alpha, '#333').forEach(f => faces.push(f));
+  });
+
+  const cx = model.bounds.width / 2;
+  const cy = model.bounds.height / 2;
+  const cz = model.bounds.depth / 2;
+  const radius = Math.sqrt(
+    model.bounds.width ** 2 +
+    model.bounds.height ** 2 +
+    model.bounds.depth ** 2
+  ) / 2;
+  const viewport = Math.min(canvas.width, canvas.height);
+  const f = 700, target = Math.max(1, viewport * 0.45);
+  const camDist = Math.max(radius + 1, radius * (1 + f / target)) * state3D.zoom;
+
+  const rotY = (p, a) => [p[0] * Math.cos(a) + p[2] * Math.sin(a), p[1], -p[0] * Math.sin(a) + p[2] * Math.cos(a)];
+  const rotX = (p, a) => [p[0], p[1] * Math.cos(a) - p[2] * Math.sin(a), p[1] * Math.sin(a) + p[2] * Math.cos(a)];
+  const proj = pt => {
+    const p0 = [pt[0] - cx, pt[1] - cy, pt[2] - cz];
+    const p1 = rotY(p0, state3D.yaw);
+    const p2 = rotX(p1, state3D.pitch);
+    const z = camDist - p2[2];
+    const s = f / z;
+    return [canvas.width / 2 + p2[0] * s, canvas.height / 2 - p2[1] * s, z];
+  };
+
+  faces.forEach(f => {
+    const tp = f.pts.map(proj);
+    f.scr = tp.map(p => [p[0], p[1]]);
+    f.avgZ = tp.reduce((a, b) => a + b[2], 0) / tp.length;
+  });
+  faces.sort((a, b) => b.avgZ - a.avgZ);
+
+  ctx.lineWidth = 1.2;
+  faces.forEach(f => {
+    ctx.beginPath();
+    f.scr.forEach((p, i) => (i ? ctx.lineTo(p[0], p[1]) : ctx.moveTo(p[0], p[1])));
+    ctx.closePath();
+    ctx.fillStyle = rgba(f.color, f.alpha);
+    ctx.strokeStyle = f.edge;
+    ctx.fill();
+    ctx.stroke();
   });
 }
+
+export function bind3dControls(canvas, render) {
+  canvas.addEventListener('dblclick', () => {
+    state3D.yaw = 0.5;
+    state3D.pitch = 0.3;
+    state3D.zoom = 1;
+    render();
+  });
+  canvas.addEventListener('wheel', e => {
+    state3D.zoom = Math.max(0.5, Math.min(3, state3D.zoom + (e.deltaY > 0 ? 0.1 : -0.1)));
+    render();
+  }, {passive: true});
+  let dragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('pointerdown', e => {
+    dragging = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    canvas.setPointerCapture(e.pointerId);
+  });
+  canvas.addEventListener('pointermove', e => {
+    if (!dragging) return;
+    const dx = e.clientX - lastX;
+    const dy = e.clientY - lastY;
+    state3D.yaw += dx * 0.01;
+    state3D.pitch = Math.max(-1.1, Math.min(1.1, state3D.pitch + dy * 0.01));
+    lastX = e.clientX;
+    lastY = e.clientY;
+    render();
+  });
+  const end = () => { dragging = false; };
+  canvas.addEventListener('pointerup', end);
+  canvas.addEventListener('pointerleave', end);
+  canvas.addEventListener('pointercancel', end);
+}
+

--- a/styles.css
+++ b/styles.css
@@ -1,2 +1,5 @@
 body{margin:0;display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);}
 canvas{width:100%;height:100%;background:#111;}
+body.single{grid-template-columns:1fr;grid-template-rows:100vh;}
+body.single canvas{display:none;}
+body.single canvas.active{display:block;}


### PR DESCRIPTION
## Summary
- compute camera center and distance from model bounds to fit geometry
- add colored 3D rendering with rotation, zoom, and reset controls
- enable toggling between quad and single view layouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc46e826c8321b82f3707a04f7679