### PR TITLE
feat: expand model builder with helper modules

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,34 @@
 export const S = {
-  width: 1000,
-  height: 1000,
-  depth: 600,
-  post: 50
+  height: 926,
+  autoHeight: true,
+  depth: 420,
+  runnerDepth: 420,
+  post: 43,
+  rearFrame: true,
+  patternText: '43,283,43,43,283,43,43',
+  rows: [
+    {height:120,gap:10,overhang:0},
+    {height:120,gap:10,overhang:0},
+    {height:120,gap:10,overhang:0},
+    {height:120,gap:10,overhang:0}
+  ],
+  topClear:10,
+  bottomClear:10,
+  bottomRowRails:false,
+  railMode:'edges',
+  topSupport:true,
+  topOrient:'X',
+  topDrop:0,
+  topSize:43,
+  bottomSupport:true,
+  bottomOrient:'X',
+  bottomLift:8,
+  bottomSize:43,
+  extraBottomBeam:false,
+  binBody:283,
+  binFlange:9.5,
+  binLip:9,
+  binSlack:6,
+  binHeightDefault:95,
+  showBins:true
 };

--- a/src/utils/autoHeight.js
+++ b/src/utils/autoHeight.js
@@ -1,0 +1,9 @@
+import {mm} from './mm.js';
+
+export function autoHeightFromRows(S){
+  const P = S.post;
+  const lintels = P * (S.rows.length + 1);
+  const heights = S.rows.reduce((a,r)=>a + mm(r.height),0);
+  const gaps = S.rows.reduce((a,r)=>a + mm(r.gap),0);
+  return lintels + mm(S.bottomClear) + mm(S.topClear) + heights + gaps;
+}

--- a/src/utils/channels.js
+++ b/src/utils/channels.js
@@ -1,0 +1,10 @@
+import {segments} from './segments.js';
+
+export function channels(S){
+  const seg = segments(S); const P=S.post; let x=0; const out=[];
+  for(const s of seg){
+    if(s!==P) out.push({x, w:s});
+    x += s;
+  }
+  return out;
+}

--- a/src/utils/computeLevels.js
+++ b/src/utils/computeLevels.js
@@ -1,0 +1,18 @@
+import {mm} from './mm.js';
+import {clamp} from './math.js';
+
+export function computeLevels(S){
+  const P = S.post;
+  let y = P + mm(S.bottomClear);
+  const out = [];
+  let overflow = false;
+  for(const r of S.rows){
+    if(!S.autoHeight && y > S.height - P){
+      overflow = true;
+      break;
+    }
+    out.push(clamp(y,0,(S.autoHeight?1e9:S.height)-P));
+    y += mm(r.height) + P + mm(r.gap);
+  }
+  return {levels:out, rowOverflow:overflow};
+}

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,0 +1,1 @@
+export const clamp = (v, min, max) => Math.max(min, Math.min(max, v));

--- a/src/utils/mm.js
+++ b/src/utils/mm.js
@@ -1,0 +1,1 @@
+export const mm = v => Number(v || 0);

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,0 +1,24 @@
+export function parseList(txt){
+  const re=/\b(\d+(?:\.\d+)?)\s*(?:mm)?\b/gi;
+  const out=[]; let m;
+  const str=String(txt);
+  while((m=re.exec(str))){
+    const n=Math.ceil(parseFloat(m[1]));
+    if(Number.isFinite(n) && n>0) out.push(n);
+  }
+  return out.length ? out : [43,283,43,43,283,43,43];
+}
+
+export function normalizeSegments(arr, post){
+  const seg = Array.isArray(arr)? arr.slice():[];
+  if(seg[0] !== post) seg.unshift(post);
+  if(seg[seg.length-1] !== post) seg.push(post);
+  const out=[]; let lastWasPost=false;
+  for(const n of seg){
+    const isPost = n===post;
+    if(isPost && lastWasPost) continue;
+    out.push(n); lastWasPost=isPost;
+  }
+  if(out.length<3) out.splice(1,0,283);
+  return out;
+}

--- a/src/utils/railXPositions.js
+++ b/src/utils/railXPositions.js
@@ -1,0 +1,4 @@
+export function railXPositions(ch, S){
+  if(S.railMode === 'centered') return [ch.x + (ch.w - S.post)/2];
+  return [ch.x, ch.x + ch.w - S.post];
+}

--- a/src/utils/segments.js
+++ b/src/utils/segments.js
@@ -1,0 +1,5 @@
+import {parseList, normalizeSegments} from './parse.js';
+
+export function segments(S){
+  return normalizeSegments(parseList(S.patternText), S.post);
+}

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -2,8 +2,11 @@ import {drawRect} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 
 export function renderFront(canvas, model) {
-  const ctx = fitCanvas(canvas, {width: model.bounds.width, height: model.bounds.height});
+  const {min, max} = model.bounds;
+  const width = max[0] - min[0];
+  const height = max[1] - min[1];
+  const ctx = fitCanvas(canvas, {width, height});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x, box.y, box.w, box.h);
+    drawRect(ctx, box.x - min[0], box.y - min[1], box.w, box.h);
   });
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -2,8 +2,11 @@ import {drawRect} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 
 export function renderPlan(canvas, model) {
-  const ctx = fitCanvas(canvas, {width: model.bounds.width, height: model.bounds.depth});
+  const {min, max} = model.bounds;
+  const width = max[0] - min[0];
+  const height = max[2] - min[2];
+  const ctx = fitCanvas(canvas, {width, height});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x, box.z, box.w, box.d);
+    drawRect(ctx, box.x - min[0], box.z - min[2], box.w, box.d);
   });
 }

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -2,8 +2,11 @@ import {drawRect} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 
 export function renderSide(canvas, model) {
-  const ctx = fitCanvas(canvas, {width: model.bounds.depth, height: model.bounds.height});
+  const {min, max} = model.bounds;
+  const width = max[2] - min[2];
+  const height = max[1] - min[1];
+  const ctx = fitCanvas(canvas, {width, height});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.z, box.y, box.d, box.h);
+    drawRect(ctx, box.z - min[2], box.y - min[1], box.d, box.h);
   });
 }

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -6,19 +6,23 @@ export function render3d(canvas, model) {
   canvas.width = canvas.clientWidth;
   canvas.height = canvas.clientHeight;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const cam = makeCamera(model.bounds);
+  const {min, max} = model.bounds;
+  const width = max[0] - min[0];
+  const height = max[1] - min[1];
+  const depth = max[2] - min[2];
+  const cam = makeCamera({width, height, depth});
   cam.cx = canvas.width / 2;
   cam.cy = canvas.height * 0.8;
   model.boxes.forEach(box => {
     const pts = [
-      {x: box.x, y: box.y, z: box.z},
-      {x: box.x + box.w, y: box.y, z: box.z},
-      {x: box.x + box.w, y: box.y + box.h, z: box.z},
-      {x: box.x, y: box.y + box.h, z: box.z},
-      {x: box.x, y: box.y, z: box.z + box.d},
-      {x: box.x + box.w, y: box.y, z: box.z + box.d},
-      {x: box.x + box.w, y: box.y + box.h, z: box.z + box.d},
-      {x: box.x, y: box.y + box.h, z: box.z + box.d}
+      {x: box.x - min[0], y: box.y - min[1], z: box.z - min[2]},
+      {x: box.x + box.w - min[0], y: box.y - min[1], z: box.z - min[2]},
+      {x: box.x + box.w - min[0], y: box.y + box.h - min[1], z: box.z - min[2]},
+      {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z - min[2]},
+      {x: box.x - min[0], y: box.y - min[1], z: box.z + box.d - min[2]},
+      {x: box.x + box.w - min[0], y: box.y - min[1], z: box.z + box.d - min[2]},
+      {x: box.x + box.w - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]},
+      {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]}
     ];
     const p = pts.map(pt => project(pt, cam));
     drawPolygon(ctx, [p[0], p[1], p[2], p[3]]);


### PR DESCRIPTION
## Summary
- add geometry helper utilities for parsing segments, channels, levels, rail positions and mm conversion
- build complete model with posts, lintels, supports, rails, bins and computed bounds
- update views to derive dimensions from new bounds structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc473d7048321a04e08f1d31450ab