### PR TITLE
Add lightweight runtime tests and npm test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 1. Clone this repository or download the source files.
 2. Open `index.html` in a modern web browser.
 3. Enter your storage pattern and dimensions. The 3D, plan, front, and side views update automatically, and cut lists are generated live.
-4. (Optional) Run in-browser checks by calling `runTests()` from the developer console.
+4. Run automated checks:
+   - Command line: `npm test`
+   - Browser console: call `runTests()`
 
 ## Version Change Log
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/main.js --bundle --format=iife --minify --outfile=dist/bundle.js",
-    "pack": "npm run build && node pack.mjs"
+    "pack": "npm run build && node pack.mjs",
+    "test": "node src/tests/index.js"
   },
   "devDependencies": {
     "esbuild": "^0.24.0"

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
 import {render3d} from './views/view3d.js';
+import './tests/index.js';
 
 function init() {
   const model = buildModel(S);

--- a/src/tests/clamp.js
+++ b/src/tests/clamp.js
@@ -1,0 +1,9 @@
+import {buildModel} from '../model.js';
+import {S as base} from '../state.js';
+
+export function testClamp(){
+  const S = {...base, depth:400, runnerDepth:500};
+  const M = buildModel(S);
+  const railsClamped = M.boxes.filter(b=>b.type==='rail').every(r=>r.d === 400);
+  return [{name:'rail depth clamped', pass:railsClamped}];
+}

--- a/src/tests/counts.js
+++ b/src/tests/counts.js
@@ -1,0 +1,12 @@
+import {buildModel} from '../model.js';
+import {S} from '../state.js';
+
+export function testCounts(){
+  const M = buildModel(S);
+  const count = type => M.boxes.filter(b=>b.type===type).length;
+  return [
+    {name:'post count', pass: count('post') === 6},
+    {name:'rail count', pass: count('rail') === 12},
+    {name:'bin count',  pass: count('bin') === 6}
+  ];
+}

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -1,0 +1,17 @@
+import {testParser} from './parser.js';
+import {testClamp} from './clamp.js';
+import {testCounts} from './counts.js';
+import {fileURLToPath} from 'url';
+
+export function runTests(){
+  const results = [...testParser(), ...testClamp(), ...testCounts()];
+  if (typeof console !== 'undefined' && console.table) console.table(results);
+  return results;
+}
+
+if (typeof window !== 'undefined') {
+  window.runTests = runTests;
+}
+
+const isMain = typeof process !== 'undefined' && process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) runTests();

--- a/src/tests/parser.js
+++ b/src/tests/parser.js
@@ -1,0 +1,15 @@
+import {parseList, normalizeSegments} from '../utils/parse.js';
+
+export function testParser(){
+  const p1 = parseList('43mm, 283, 43, junk');
+  const exp1 = [43,283,43];
+  const parsePass = exp1.every((n,i) => p1[i] === n);
+
+  const p2 = normalizeSegments([43,43,283,43,43], 43);
+  const normPass = p2.length === 3 && p2[0]===43 && p2[1]===283 && p2[2]===43;
+
+  return [
+    {name:'parseList basic', pass:parsePass},
+    {name:'normalizeSegments dedup', pass:normPass}
+  ];
+}


### PR DESCRIPTION
## Summary
- add simple parser, clamp, and count tests with a runTests() helper
- expose runTests() globally and wire up via npm test script
- document command-line and browser ways to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc6fa8ee88321a5092739b54c2271