### PR TITLE
Add reactive state manager with interactive controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,14 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
+    <form id="controls">
+      <label>Height <input id="height-input" type="number" /></label>
+      <label>Depth <input id="depth-input" type="number" /></label>
+      <label>Post <input id="post-input" type="number" /></label>
+      <label>Pattern <input id="pattern-input" type="text" /></label>
+      <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
+      <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
+    </form>
     <canvas id="front"></canvas>
     <canvas id="side"></canvas>
     <canvas id="plan"></canvas>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,13 @@
-import {S} from './state.js';
+import {
+  getState,
+  subscribe,
+  setHeight,
+  setDepth,
+  setPost,
+  setPatternText,
+  toggleRearFrame,
+  toggleShowBins
+} from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
@@ -6,12 +15,32 @@ import {renderPlan} from './views/plan.js';
 import {render3d} from './views/view3d.js';
 import './tests/index.js';
 
-function init() {
-  const model = buildModel(S);
+function render(){
+  const model = buildModel(getState());
   renderFront(document.getElementById('front'), model);
   renderSide(document.getElementById('side'), model);
   renderPlan(document.getElementById('plan'), model);
   render3d(document.getElementById('three'), model);
+}
+
+function init() {
+  const s = getState();
+  document.getElementById('height-input').value = s.height;
+  document.getElementById('depth-input').value = s.depth;
+  document.getElementById('post-input').value = s.post;
+  document.getElementById('pattern-input').value = s.patternText;
+  document.getElementById('rearFrame-toggle').checked = s.rearFrame;
+  document.getElementById('showBins-toggle').checked = s.showBins;
+
+  document.getElementById('height-input').addEventListener('input', e=>setHeight(e.target.value));
+  document.getElementById('depth-input').addEventListener('input', e=>setDepth(e.target.value));
+  document.getElementById('post-input').addEventListener('input', e=>setPost(e.target.value));
+  document.getElementById('pattern-input').addEventListener('input', e=>setPatternText(e.target.value));
+  document.getElementById('rearFrame-toggle').addEventListener('change', e=>toggleRearFrame(e.target.checked));
+  document.getElementById('showBins-toggle').addEventListener('change', e=>toggleShowBins(e.target.checked));
+
+  subscribe(render);
+  render();
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/src/state.js
+++ b/src/state.js
@@ -1,4 +1,4 @@
-export const S = {
+const state = {
   height: 926,
   autoHeight: true,
   depth: 420,
@@ -32,3 +32,49 @@ export const S = {
   binHeightDefault:95,
   showBins:true
 };
+
+const listeners = new Set();
+
+function notify(){
+  for(const fn of listeners) fn(state);
+}
+
+export function getState(){
+  return state;
+}
+
+export function subscribe(fn){
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function setHeight(value){
+  state.height = Number(value);
+  state.autoHeight = false;
+  notify();
+}
+
+export function setDepth(value){
+  state.depth = Number(value);
+  notify();
+}
+
+export function setPost(value){
+  state.post = Number(value);
+  notify();
+}
+
+export function setPatternText(value){
+  state.patternText = value;
+  notify();
+}
+
+export function toggleRearFrame(value){
+  state.rearFrame = value;
+  notify();
+}
+
+export function toggleShowBins(value){
+  state.showBins = value;
+  notify();
+}

--- a/src/tests/clamp.js
+++ b/src/tests/clamp.js
@@ -1,7 +1,8 @@
 import {buildModel} from '../model.js';
-import {S as base} from '../state.js';
+import {getState} from '../state.js';
 
 export function testClamp(){
+  const base = getState();
   const S = {...base, depth:400, runnerDepth:500};
   const M = buildModel(S);
   const railsClamped = M.boxes.filter(b=>b.type==='rail').every(r=>r.d === 400);

--- a/src/tests/counts.js
+++ b/src/tests/counts.js
@@ -1,8 +1,8 @@
 import {buildModel} from '../model.js';
-import {S} from '../state.js';
+import {getState} from '../state.js';
 
 export function testCounts(){
-  const M = buildModel(S);
+  const M = buildModel(getState());
   const count = type => M.boxes.filter(b=>b.type===type).length;
   return [
     {name:'post count', pass: count('post') === 6},


### PR DESCRIPTION
## Summary
- replace static state with reactive manager and setters
- add form inputs for dimensions, pattern text and feature toggles
- re-render views and tests updated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc9e7d7b883219dd2e44e05f4050a