### PR TITLE
feat: add view overlays and color mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
       <label>Pattern <input id="pattern-input" type="text" /></label>
       <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
       <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
+      <label><input id="showDimensions-toggle" type="checkbox" /> Show Dimensions</label>
+      <label><input id="showOpenings-toggle" type="checkbox" /> Plan Openings</label>
     </form>
     <canvas id="front"></canvas>
     <canvas id="side"></canvas>

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,9 @@ import {
   setPost,
   setPatternText,
   toggleRearFrame,
-  toggleShowBins
+  toggleShowBins,
+  toggleShowDimensions,
+  toggleShowOpenings
 } from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
@@ -16,10 +18,11 @@ import {render3d} from './views/view3d.js';
 import './tests/index.js';
 
 function render(){
-  const model = buildModel(getState());
-  renderFront(document.getElementById('front'), model);
-  renderSide(document.getElementById('side'), model);
-  renderPlan(document.getElementById('plan'), model);
+  const s = getState();
+  const model = buildModel(s);
+  renderFront(document.getElementById('front'), model, {dimensions: s.showDimensions});
+  renderSide(document.getElementById('side'), model, {dimensions: s.showDimensions});
+  renderPlan(document.getElementById('plan'), model, {dimensions: s.showDimensions, openings: s.showOpenings});
   render3d(document.getElementById('three'), model);
 }
 
@@ -31,6 +34,8 @@ function init() {
   document.getElementById('pattern-input').value = s.patternText;
   document.getElementById('rearFrame-toggle').checked = s.rearFrame;
   document.getElementById('showBins-toggle').checked = s.showBins;
+  document.getElementById('showDimensions-toggle').checked = s.showDimensions;
+  document.getElementById('showOpenings-toggle').checked = s.showOpenings;
 
   document.getElementById('height-input').addEventListener('input', e=>setHeight(e.target.value));
   document.getElementById('depth-input').addEventListener('input', e=>setDepth(e.target.value));
@@ -38,6 +43,8 @@ function init() {
   document.getElementById('pattern-input').addEventListener('input', e=>setPatternText(e.target.value));
   document.getElementById('rearFrame-toggle').addEventListener('change', e=>toggleRearFrame(e.target.checked));
   document.getElementById('showBins-toggle').addEventListener('change', e=>toggleShowBins(e.target.checked));
+  document.getElementById('showDimensions-toggle').addEventListener('change', e=>toggleShowDimensions(e.target.checked));
+  document.getElementById('showOpenings-toggle').addEventListener('change', e=>toggleShowOpenings(e.target.checked));
 
   subscribe(render);
   render();

--- a/src/state.js
+++ b/src/state.js
@@ -30,7 +30,9 @@ const state = {
   binLip:9,
   binSlack:6,
   binHeightDefault:95,
-  showBins:true
+  showBins:true,
+  showDimensions:false,
+  showOpenings:false
 };
 
 const listeners = new Set();
@@ -76,5 +78,15 @@ export function toggleRearFrame(value){
 
 export function toggleShowBins(value){
   state.showBins = value;
+  notify();
+}
+
+export function toggleShowDimensions(value){
+  state.showDimensions = value;
+  notify();
+}
+
+export function toggleShowOpenings(value){
+  state.showOpenings = value;
   notify();
 }

--- a/src/utils/draw2d.js
+++ b/src/utils/draw2d.js
@@ -14,3 +14,24 @@ export function drawPolygon(ctx, points, color = '#fff') {
   ctx.closePath();
   ctx.stroke();
 }
+
+export function drawLabel(ctx, x, y, text, color = '#fff') {
+  ctx.save();
+  ctx.scale(1, -1);
+  ctx.fillStyle = color;
+  ctx.font = '12px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, x, -y);
+  ctx.restore();
+}
+
+export function drawCross(ctx, x, y, w, h, color = '#fff') {
+  ctx.strokeStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x + w, y + h);
+  ctx.moveTo(x + w, y);
+  ctx.lineTo(x, y + h);
+  ctx.stroke();
+}

--- a/src/utils/fit.js
+++ b/src/utils/fit.js
@@ -1,10 +1,15 @@
 export function fitCanvas(canvas, bounds) {
+  const {min, max} = bounds;
+  const width = max[0] - min[0];
+  const height = max[1] - min[1];
   const ctx = canvas.getContext('2d');
   canvas.width = canvas.clientWidth;
   canvas.height = canvas.clientHeight;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const scale = Math.min(canvas.width / bounds.width, canvas.height / bounds.height);
-  ctx.setTransform(scale, 0, 0, -scale, 0, canvas.height);
+  const scale = Math.min(canvas.width / width, canvas.height / height);
+  const tx = -min[0] * scale;
+  const ty = canvas.height + min[1] * scale;
+  ctx.setTransform(scale, 0, 0, -scale, tx, ty);
   return ctx;
 }

--- a/src/utils/typeColors.js
+++ b/src/utils/typeColors.js
@@ -1,0 +1,7 @@
+export const TYPE_COLORS = {
+  post: '#f66',
+  rail: '#6f6',
+  bin: '#66f',
+  support: '#fc6',
+  lintel: '#f6f'
+};

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,12 +1,16 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawLabel} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {TYPE_COLORS} from '../utils/typeColors.js';
 
-export function renderFront(canvas, model) {
+export function renderFront(canvas, model, options = {}) {
   const {min, max} = model.bounds;
-  const width = max[0] - min[0];
-  const height = max[1] - min[1];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min: [min[0], min[1]], max: [max[0], max[1]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x - min[0], box.y - min[1], box.w, box.h);
+    const color = TYPE_COLORS[box.type] || '#fff';
+    drawRect(ctx, box.x, box.y, box.w, box.h, color);
+    if (options.dimensions) {
+      const label = `${Math.round(box.w)}×${Math.round(box.h)}`;
+      drawLabel(ctx, box.x + box.w / 2, box.y + box.h / 2, label, color);
+    }
   });
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,12 +1,19 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawLabel, drawCross} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {TYPE_COLORS} from '../utils/typeColors.js';
 
-export function renderPlan(canvas, model) {
+export function renderPlan(canvas, model, options = {}) {
   const {min, max} = model.bounds;
-  const width = max[0] - min[0];
-  const height = max[2] - min[2];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min: [min[0], min[2]], max: [max[0], max[2]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x - min[0], box.z - min[2], box.w, box.d);
+    const color = TYPE_COLORS[box.type] || '#fff';
+    drawRect(ctx, box.x, box.z, box.w, box.d, color);
+    if (options.dimensions) {
+      const label = `${Math.round(box.w)}×${Math.round(box.d)}`;
+      drawLabel(ctx, box.x + box.w / 2, box.z + box.d / 2, label, color);
+    }
+    if (options.openings && box.type === 'bin') {
+      drawCross(ctx, box.x, box.z, box.w, box.d, color);
+    }
   });
 }

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,12 +1,16 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawLabel} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {TYPE_COLORS} from '../utils/typeColors.js';
 
-export function renderSide(canvas, model) {
+export function renderSide(canvas, model, options = {}) {
   const {min, max} = model.bounds;
-  const width = max[2] - min[2];
-  const height = max[1] - min[1];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min: [min[2], min[1]], max: [max[2], max[1]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.z - min[2], box.y - min[1], box.d, box.h);
+    const color = TYPE_COLORS[box.type] || '#fff';
+    drawRect(ctx, box.z, box.y, box.d, box.h, color);
+    if (options.dimensions) {
+      const label = `${Math.round(box.d)}×${Math.round(box.h)}`;
+      drawLabel(ctx, box.z + box.d / 2, box.y + box.h / 2, label, color);
+    }
   });
 }

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,5 +1,6 @@
 import {drawPolygon} from '../utils/draw2d.js';
 import {makeCamera, project} from '../utils/camera3d.js';
+import {TYPE_COLORS} from '../utils/typeColors.js';
 
 export function render3d(canvas, model) {
   const ctx = canvas.getContext('2d');
@@ -14,6 +15,7 @@ export function render3d(canvas, model) {
   cam.cx = canvas.width / 2;
   cam.cy = canvas.height * 0.8;
   model.boxes.forEach(box => {
+    const color = TYPE_COLORS[box.type] || '#fff';
     const pts = [
       {x: box.x - min[0], y: box.y - min[1], z: box.z - min[2]},
       {x: box.x + box.w - min[0], y: box.y - min[1], z: box.z - min[2]},
@@ -25,13 +27,13 @@ export function render3d(canvas, model) {
       {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]}
     ];
     const p = pts.map(pt => project(pt, cam));
-    drawPolygon(ctx, [p[0], p[1], p[2], p[3]]);
-    drawPolygon(ctx, [p[4], p[5], p[6], p[7]]);
+    drawPolygon(ctx, [p[0], p[1], p[2], p[3]], color);
+    drawPolygon(ctx, [p[4], p[5], p[6], p[7]], color);
     for (let i = 0; i < 4; i++) {
       ctx.beginPath();
       ctx.moveTo(p[i].x, p[i].y);
       ctx.lineTo(p[i + 4].x, p[i + 4].y);
-      ctx.strokeStyle = '#fff';
+      ctx.strokeStyle = color;
       ctx.stroke();
     }
   });


### PR DESCRIPTION
## Summary
- color-code posts, rails, bins, supports and lintels across all views
- add optional dimension labels and plan opening markers
- fit canvas using model min/max bounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adce13e2e08321969b800e97980309