### PR TITLE
Color-coded views with optional overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <label>Pattern <input id="pattern-input" type="text" /></label>
       <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
       <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
+      <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
     </form>
     <canvas id="front"></canvas>
     <canvas id="side"></canvas>

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,8 @@ import {
   setPost,
   setPatternText,
   toggleRearFrame,
-  toggleShowBins
+  toggleShowBins,
+  toggleOverlays
 } from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
@@ -17,10 +18,11 @@ import './tests/index.js';
 
 function render(){
   const model = buildModel(getState());
-  renderFront(document.getElementById('front'), model);
-  renderSide(document.getElementById('side'), model);
-  renderPlan(document.getElementById('plan'), model);
-  render3d(document.getElementById('three'), model);
+  const o = getState().showOverlays;
+  renderFront(document.getElementById('front'), model, o);
+  renderSide(document.getElementById('side'), model, o);
+  renderPlan(document.getElementById('plan'), model, o);
+  render3d(document.getElementById('three'), model, o);
 }
 
 function init() {
@@ -31,6 +33,7 @@ function init() {
   document.getElementById('pattern-input').value = s.patternText;
   document.getElementById('rearFrame-toggle').checked = s.rearFrame;
   document.getElementById('showBins-toggle').checked = s.showBins;
+  document.getElementById('overlay-toggle').checked = s.showOverlays;
 
   document.getElementById('height-input').addEventListener('input', e=>setHeight(e.target.value));
   document.getElementById('depth-input').addEventListener('input', e=>setDepth(e.target.value));
@@ -38,6 +41,7 @@ function init() {
   document.getElementById('pattern-input').addEventListener('input', e=>setPatternText(e.target.value));
   document.getElementById('rearFrame-toggle').addEventListener('change', e=>toggleRearFrame(e.target.checked));
   document.getElementById('showBins-toggle').addEventListener('change', e=>toggleShowBins(e.target.checked));
+  document.getElementById('overlay-toggle').addEventListener('change', e=>toggleOverlays(e.target.checked));
 
   subscribe(render);
   render();

--- a/src/state.js
+++ b/src/state.js
@@ -30,7 +30,8 @@ const state = {
   binLip:9,
   binSlack:6,
   binHeightDefault:95,
-  showBins:true
+  showBins:true,
+  showOverlays:false
 };
 
 const listeners = new Set();
@@ -76,5 +77,10 @@ export function toggleRearFrame(value){
 
 export function toggleShowBins(value){
   state.showBins = value;
+  notify();
+}
+
+export function toggleOverlays(value){
+  state.showOverlays = value;
   notify();
 }

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,0 +1,7 @@
+export const typeColors = {
+  post: '#8d5524',
+  rail: '#b22222',
+  bin: '#1e90ff',
+  support: '#228b22',
+  lintel: '#daa520'
+};

--- a/src/utils/draw2d.js
+++ b/src/utils/draw2d.js
@@ -14,3 +14,16 @@ export function drawPolygon(ctx, points, color = '#fff') {
   ctx.closePath();
   ctx.stroke();
 }
+
+export function drawText(ctx, text, x, y, color = '#fff', align = 'center') {
+  const m = ctx.getTransform();
+  const sx = x * m.a + m.e;
+  const sy = y * m.d + m.f;
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = color;
+  ctx.textAlign = align;
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, sx, sy);
+  ctx.restore();
+}

--- a/src/utils/fit.js
+++ b/src/utils/fit.js
@@ -4,7 +4,9 @@ export function fitCanvas(canvas, bounds) {
   canvas.height = canvas.clientHeight;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const scale = Math.min(canvas.width / bounds.width, canvas.height / bounds.height);
-  ctx.setTransform(scale, 0, 0, -scale, 0, canvas.height);
+  const width = bounds.max[0] - bounds.min[0];
+  const height = bounds.max[1] - bounds.min[1];
+  const scale = Math.min(canvas.width / width, canvas.height / height);
+  ctx.setTransform(scale, 0, 0, -scale, -bounds.min[0] * scale, canvas.height + bounds.min[1] * scale);
   return ctx;
 }

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,12 +1,23 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawText} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {typeColors} from '../utils/colors.js';
 
-export function renderFront(canvas, model) {
+export function renderFront(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
-  const width = max[0] - min[0];
-  const height = max[1] - min[1];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min:[min[0], min[1]], max:[max[0], max[1]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x - min[0], box.y - min[1], box.w, box.h);
+    const color = typeColors[box.type] || '#fff';
+    drawRect(ctx, box.x, box.y, box.w, box.h, color);
   });
+    if (overlays) {
+      const scale = ctx.getTransform().a;
+      drawText(
+        ctx,
+        `W:${Math.round(max[0]-min[0])} H:${Math.round(max[1]-min[1])}`,
+        min[0] + 2/scale,
+        max[1] + 12/scale,
+        '#0f0',
+        'left'
+      );
+    }
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,12 +1,32 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawText} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {typeColors} from '../utils/colors.js';
 
-export function renderPlan(canvas, model) {
+export function renderPlan(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
-  const width = max[0] - min[0];
-  const height = max[2] - min[2];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min:[min[0], min[2]], max:[max[0], max[2]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.x - min[0], box.z - min[2], box.w, box.d);
+    const color = typeColors[box.type] || '#fff';
+    drawRect(ctx, box.x, box.z, box.w, box.d, color);
   });
+  if (overlays) {
+    const scale = ctx.getTransform().a;
+    drawText(
+      ctx,
+      `W:${Math.round(max[0]-min[0])} D:${Math.round(max[2]-min[2])}`,
+      min[0] + 2/scale,
+      max[2] + 12/scale,
+      '#0f0',
+      'left'
+    );
+    model.channels.forEach(c => {
+      const cx = c.x + c.w / 2;
+      drawText(ctx, Math.round(c.w).toString(), cx, max[2] + 12/scale, '#0f0');
+      ctx.beginPath();
+      ctx.moveTo(cx, min[2]);
+      ctx.lineTo(cx, max[2]);
+      ctx.strokeStyle = '#0f0';
+      ctx.stroke();
+    });
+  }
 }

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,12 +1,23 @@
-import {drawRect} from '../utils/draw2d.js';
+import {drawRect, drawText} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
+import {typeColors} from '../utils/colors.js';
 
-export function renderSide(canvas, model) {
+export function renderSide(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
-  const width = max[2] - min[2];
-  const height = max[1] - min[1];
-  const ctx = fitCanvas(canvas, {width, height});
+  const ctx = fitCanvas(canvas, {min:[min[2], min[1]], max:[max[2], max[1]]});
   model.boxes.forEach(box => {
-    drawRect(ctx, box.z - min[2], box.y - min[1], box.d, box.h);
+    const color = typeColors[box.type] || '#fff';
+    drawRect(ctx, box.z, box.y, box.d, box.h, color);
   });
+  if (overlays) {
+    const scale = ctx.getTransform().a;
+    drawText(
+      ctx,
+      `D:${Math.round(max[2]-min[2])} H:${Math.round(max[1]-min[1])}`,
+      min[2] + 2/scale,
+      max[1] + 12/scale,
+      '#0f0',
+      'left'
+    );
+  }
 }

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,7 +1,8 @@
-import {drawPolygon} from '../utils/draw2d.js';
+import {drawPolygon, drawText} from '../utils/draw2d.js';
 import {makeCamera, project} from '../utils/camera3d.js';
+import {typeColors} from '../utils/colors.js';
 
-export function render3d(canvas, model) {
+export function render3d(canvas, model, overlays = false) {
   const ctx = canvas.getContext('2d');
   canvas.width = canvas.clientWidth;
   canvas.height = canvas.clientHeight;
@@ -25,14 +26,18 @@ export function render3d(canvas, model) {
       {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]}
     ];
     const p = pts.map(pt => project(pt, cam));
-    drawPolygon(ctx, [p[0], p[1], p[2], p[3]]);
-    drawPolygon(ctx, [p[4], p[5], p[6], p[7]]);
+    const color = typeColors[box.type] || '#fff';
+    drawPolygon(ctx, [p[0], p[1], p[2], p[3]], color);
+    drawPolygon(ctx, [p[4], p[5], p[6], p[7]], color);
     for (let i = 0; i < 4; i++) {
       ctx.beginPath();
       ctx.moveTo(p[i].x, p[i].y);
       ctx.lineTo(p[i + 4].x, p[i + 4].y);
-      ctx.strokeStyle = '#fff';
+      ctx.strokeStyle = color;
       ctx.stroke();
     }
   });
+  if (overlays) {
+    drawText(ctx, `W:${Math.round(width)} H:${Math.round(height)} D:${Math.round(depth)}`, 10, 20, '#0f0', 'left');
+  }
 }


### PR DESCRIPTION
## Summary
- Color-code posts, rails, bins, supports, and lintels across all views
- Add overlay toggle for dimension labels and plan opening markers
- Improve canvas fitting by accepting model bounds (min/max)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adce13e2e08321969b800e97980309