### PR TITLE
Add camera fit, shading, and view controls to 3D view

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,19 @@
       <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
       <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
     </form>
-    <canvas id="front"></canvas>
-    <canvas id="side"></canvas>
-    <canvas id="plan"></canvas>
-    <canvas id="three"></canvas>
+    <div id="view-controls">
+      <button data-view="quad">Quad</button>
+      <button data-view="three">3D</button>
+      <button data-view="plan">Plan</button>
+      <button data-view="front">Front</button>
+      <button data-view="side">Side</button>
+    </div>
+    <div id="views">
+      <canvas id="front"></canvas>
+      <canvas id="side"></canvas>
+      <canvas id="plan"></canvas>
+      <canvas id="three"></canvas>
+    </div>
 
     <script type="module" src="./src/main.js"></script>
     <!-- PACK:INLINE_JS -->

--- a/src/main.js
+++ b/src/main.js
@@ -7,13 +7,14 @@ import {
   setPatternText,
   toggleRearFrame,
   toggleShowBins,
-  toggleOverlays
+  toggleOverlays,
+  setViewMode
 } from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
-import {render3d} from './views/view3d.js';
+import {render3d, init3dControls} from './views/view3d.js';
 import './tests/index.js';
 
 function render(){
@@ -23,6 +24,12 @@ function render(){
   renderSide(document.getElementById('side'), model, o);
   renderPlan(document.getElementById('plan'), model, o);
   render3d(document.getElementById('three'), model, o);
+
+  const vm = getState().viewMode;
+  document.body.classList.toggle('single', vm !== 'quad');
+  document.querySelectorAll('#views canvas').forEach(c=>{
+    c.classList.toggle('active', vm === 'quad' ? true : c.id === vm);
+  });
 }
 
 function init() {
@@ -42,6 +49,19 @@ function init() {
   document.getElementById('rearFrame-toggle').addEventListener('change', e=>toggleRearFrame(e.target.checked));
   document.getElementById('showBins-toggle').addEventListener('change', e=>toggleShowBins(e.target.checked));
   document.getElementById('overlay-toggle').addEventListener('change', e=>toggleOverlays(e.target.checked));
+
+  document.querySelectorAll('#view-controls button').forEach(btn=>{
+    btn.addEventListener('click', ()=>setViewMode(btn.dataset.view));
+  });
+
+  document.querySelectorAll('#views canvas').forEach(cvs=>{
+    cvs.addEventListener('click', ()=>{
+      const vm = getState().viewMode;
+      setViewMode(vm === 'quad' ? cvs.id : 'quad');
+    });
+  });
+
+  init3dControls(document.getElementById('three'));
 
   subscribe(render);
   render();

--- a/src/state.js
+++ b/src/state.js
@@ -31,7 +31,13 @@ const state = {
   binSlack:6,
   binHeightDefault:95,
   showBins:true,
-  showOverlays:false
+  showOverlays:false,
+
+  // view / camera state
+  viewMode:'quad', // 'quad' | 'three' | 'plan' | 'front' | 'side'
+  yaw:0.5,
+  pitch:0.3,
+  zoom:1
 };
 
 const listeners = new Set();
@@ -83,4 +89,16 @@ export function toggleShowBins(value){
 export function toggleOverlays(value){
   state.showOverlays = value;
   notify();
+}
+
+export function setViewMode(mode){
+  state.viewMode = mode;
+  notify();
+}
+
+export function setCamera({yaw=state.yaw, pitch=state.pitch, zoom=state.zoom}, notifyChange=true){
+  state.yaw = yaw;
+  state.pitch = pitch;
+  state.zoom = zoom;
+  if(notifyChange) notify();
 }

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,43 +1,133 @@
-import {drawPolygon, drawText} from '../utils/draw2d.js';
-import {makeCamera, project} from '../utils/camera3d.js';
 import {typeColors} from '../utils/colors.js';
+import {getState, setCamera} from '../state.js';
 
-export function render3d(canvas, model, overlays = false) {
-  const ctx = canvas.getContext('2d');
-  canvas.width = canvas.clientWidth;
-  canvas.height = canvas.clientHeight;
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const {min, max} = model.bounds;
-  const width = max[0] - min[0];
-  const height = max[1] - min[1];
-  const depth = max[2] - min[2];
-  const cam = makeCamera({width, height, depth});
-  cam.cx = canvas.width / 2;
-  cam.cy = canvas.height * 0.8;
-  model.boxes.forEach(box => {
-    const pts = [
-      {x: box.x - min[0], y: box.y - min[1], z: box.z - min[2]},
-      {x: box.x + box.w - min[0], y: box.y - min[1], z: box.z - min[2]},
-      {x: box.x + box.w - min[0], y: box.y + box.h - min[1], z: box.z - min[2]},
-      {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z - min[2]},
-      {x: box.x - min[0], y: box.y - min[1], z: box.z + box.d - min[2]},
-      {x: box.x + box.w - min[0], y: box.y - min[1], z: box.z + box.d - min[2]},
-      {x: box.x + box.w - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]},
-      {x: box.x - min[0], y: box.y + box.h - min[1], z: box.z + box.d - min[2]}
-    ];
-    const p = pts.map(pt => project(pt, cam));
-    const color = typeColors[box.type] || '#fff';
-    drawPolygon(ctx, [p[0], p[1], p[2], p[3]], color);
-    drawPolygon(ctx, [p[4], p[5], p[6], p[7]], color);
-    for (let i = 0; i < 4; i++) {
-      ctx.beginPath();
-      ctx.moveTo(p[i].x, p[i].y);
-      ctx.lineTo(p[i + 4].x, p[i + 4].y);
-      ctx.strokeStyle = color;
-      ctx.stroke();
+const camState = {yaw:0.5, pitch:0.3, zoom:1};
+let canvasRef, modelRef, overlayRef;
+
+function shadeColor(hex, factor){
+  const r=parseInt(hex.slice(1,3),16);
+  const g=parseInt(hex.slice(3,5),16);
+  const b=parseInt(hex.slice(5,7),16);
+  const f=Math.max(0, Math.min(1,factor));
+  return `rgb(${Math.round(r*f)},${Math.round(g*f)},${Math.round(b*f)})`;
+}
+
+function makeBoxFaces(x,y,z,w,h,d){
+  const v=[[x,y,z],[x+w,y,z],[x+w,y+h,z],[x,y+h,z],[x,y,z+d],[x+w,y,z+d],[x+w,y+h,z+d],[x,y+h,z+d]];
+  const q=[[0,1,2,3],[4,5,6,7],[0,4,7,3],[1,5,6,2],[0,1,5,4],[3,2,6,7]];
+  return q.map(idx=>idx.map(i=>v[i]));
+}
+
+export function render3d(canvas, model, overlays=false){
+  canvasRef=canvas; modelRef=model; overlayRef=overlays;
+  const s=getState();
+  camState.yaw=s.yaw; camState.pitch=s.pitch; camState.zoom=s.zoom;
+  const ctx=canvas.getContext('2d');
+  canvas.width=canvas.clientWidth; canvas.height=canvas.clientHeight;
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+
+  const {min,max}=model.bounds;
+  const cx=(min[0]+max[0])/2;
+  const cy=(min[1]+max[1])/2;
+  const cz=(min[2]+max[2])/2;
+  const radius=Math.sqrt((max[0]-min[0])**2+(max[1]-min[1])**2+(max[2]-min[2])**2)/2;
+
+  const viewport=Math.min(canvas.width, canvas.height);
+  const f=700;
+  const target=Math.max(1, viewport*0.45);
+  const camDist=Math.max(radius+1, radius*(1+f/target))*camState.zoom;
+  const rotY=(p,a)=>[p[0]*Math.cos(a)+p[2]*Math.sin(a), p[1], -p[0]*Math.sin(a)+p[2]*Math.cos(a)];
+  const rotX=(p,a)=>[p[0], p[1]*Math.cos(a)-p[2]*Math.sin(a), p[1]*Math.sin(a)+p[2]*Math.cos(a)];
+
+  const faces=[];
+  model.boxes.forEach(b=>{
+    const base=typeColors[b.type]||'#ddd';
+    makeBoxFaces(b.x,b.y,b.z,b.w,b.h,b.d).forEach(facePts=>{
+      const tp=facePts.map(pt=>{
+        const p0=[pt[0]-cx, pt[1]-cy, pt[2]-cz];
+        const p1=rotY(p0,camState.yaw);
+        const p2=rotX(p1,camState.pitch);
+        const z=camDist-p2[2];
+        const s=f/z;
+        return {x:canvas.width/2+p2[0]*s,y:canvas.height/2-p2[1]*s,z,p:p2};
+      });
+      const u=[tp[1].p[0]-tp[0].p[0], tp[1].p[1]-tp[0].p[1], tp[1].p[2]-tp[0].p[2]];
+      const v=[tp[2].p[0]-tp[1].p[0], tp[2].p[1]-tp[1].p[1], tp[2].p[2]-tp[1].p[2]];
+      const normal=[u[1]*v[2]-u[2]*v[1], u[2]*v[0]-u[0]*v[2], u[0]*v[1]-u[1]*v[0]];
+      const nlen=Math.hypot(normal[0],normal[1],normal[2])||1;
+      const light=Math.max(0, normal[2]/nlen);
+      const shade=0.3+0.7*light;
+      const color=shadeColor(base, shade);
+      const avgZ=tp.reduce((a,b)=>a+b.z,0)/tp.length;
+      faces.push({pts:tp.map(p=>[p.x,p.y]), avgZ, color, edge:base});
+    });
+  });
+
+  faces.sort((a,b)=>b.avgZ-a.avgZ);
+  ctx.lineWidth=1;
+  faces.forEach(f=>{
+    ctx.beginPath();
+    f.pts.forEach((p,i)=> i?ctx.lineTo(p[0],p[1]):ctx.moveTo(p[0],p[1]));
+    ctx.closePath();
+    ctx.fillStyle=f.color; ctx.strokeStyle=f.edge;
+    ctx.fill(); ctx.stroke();
+  });
+
+  if(overlays){
+    const width=max[0]-min[0];
+    const height=max[1]-min[1];
+    const depth=max[2]-min[2];
+    ctx.fillStyle='#0f0';
+    ctx.font='12px sans-serif';
+    ctx.fillText(`W:${Math.round(width)} H:${Math.round(height)} D:${Math.round(depth)}`,10,20);
+  }
+}
+
+function clamp(v,min,max){return v<min?min:v>max?max:v;}
+
+export function init3dControls(canvas){
+  canvas.addEventListener('dblclick',()=>{
+    camState.yaw=0.5; camState.pitch=0.3; camState.zoom=1;
+    setCamera(camState,false);
+    render3d(canvasRef, modelRef, overlayRef);
+  });
+  canvas.addEventListener('wheel',e=>{
+    camState.zoom=clamp(camState.zoom+(e.deltaY>0?0.1:-0.1),0.5,3);
+    setCamera(camState,false);
+    render3d(canvasRef, modelRef, overlayRef);
+  },{passive:true});
+  const pointers=new Map();
+  let pinchDist=0,pinchZoom=1;
+  const pos=e=>({x:e.clientX,y:e.clientY});
+  const dist=(a,b)=>Math.hypot(a.x-b.x,a.y-b.y);
+  const end=e=>{pointers.delete(e.pointerId); if(pointers.size<2) pinchDist=0;};
+  canvas.addEventListener('pointerup',end);
+  canvas.addEventListener('pointerleave',end);
+  canvas.addEventListener('pointercancel',end);
+  canvas.addEventListener('pointerdown',e=>{
+    pointers.set(e.pointerId,pos(e));
+    if(pointers.size===2){
+      const [p1,p2]=Array.from(pointers.values());
+      pinchDist=dist(p1,p2); pinchZoom=camState.zoom;
+    }
+    canvas.setPointerCapture(e.pointerId);
+  });
+  canvas.addEventListener('pointermove',e=>{
+    if(!pointers.has(e.pointerId)) return;
+    const prev=pointers.get(e.pointerId), curr=pos(e);
+    pointers.set(e.pointerId,curr);
+    if(pointers.size===1){
+      const dx=curr.x-prev.x, dy=curr.y-prev.y;
+      camState.yaw+=dx*0.01;
+      camState.pitch=clamp(camState.pitch+dy*0.01,-1.1,1.1);
+      setCamera(camState,false);
+      render3d(canvasRef, modelRef, overlayRef);
+    }else if(pointers.size===2){
+      const [p1,p2]=Array.from(pointers.values());
+      const d=dist(p1,p2);
+      camState.zoom=clamp(pinchZoom*(pinchDist/d),0.5,3);
+      setCamera(camState,false);
+      render3d(canvasRef, modelRef, overlayRef);
     }
   });
-  if (overlays) {
-    drawText(ctx, `W:${Math.round(width)} H:${Math.round(height)} D:${Math.round(depth)}`, 10, 20, '#0f0', 'left');
-  }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,2 +1,7 @@
-body{margin:0;display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);}
-canvas{width:100%;height:100%;background:#111;}
+body{margin:0;}
+#view-controls{margin:4px;}
+#views{display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,50vh);}
+canvas{width:100%;height:100%;background:#111;display:block;}
+body.single #views{grid-template-columns:1fr;grid-template-rows:100vh;}
+body.single #views canvas{display:none;}
+body.single #views canvas.active{display:block;}


### PR DESCRIPTION
## Summary
- Fit 3D camera to model bounds and add basic face shading
- Add rotation/zoom controls plus Quad↔Single view switching
- Track view and camera state in shared state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add0608a34832184b8d40e962a05ee