### PR TITLE
Clamp numeric state setters

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -46,6 +46,11 @@ function notify(){
   for(const fn of listeners) fn(state);
 }
 
+function parseNumber(value, min = 0){
+  const num = Number(value);
+  return Number.isFinite(num) && num >= min ? num : min;
+}
+
 export function getState(){
   return state;
 }
@@ -56,18 +61,18 @@ export function subscribe(fn){
 }
 
 export function setHeight(value){
-  state.height = Number(value);
+  state.height = parseNumber(value, 0);
   state.autoHeight = false;
   notify();
 }
 
 export function setDepth(value){
-  state.depth = Number(value);
+  state.depth = parseNumber(value, 0);
   notify();
 }
 
 export function setPost(value){
-  state.post = Number(value);
+  state.post = parseNumber(value, 0);
   notify();
 }
 
@@ -97,8 +102,8 @@ export function setViewMode(mode){
 }
 
 export function setCamera({yaw=state.yaw, pitch=state.pitch, zoom=state.zoom}, notifyChange=true){
-  state.yaw = yaw;
-  state.pitch = pitch;
-  state.zoom = zoom;
+  state.yaw = parseNumber(yaw, 0);
+  state.pitch = parseNumber(pitch, 0);
+  state.zoom = parseNumber(zoom, 0);
   if(notifyChange) notify();
 }

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -1,10 +1,11 @@
 import {testParser} from './parser.js';
 import {testClamp} from './clamp.js';
 import {testCounts} from './counts.js';
+import {testStateSetters} from './state-setters.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts()];
+  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters()];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }

--- a/src/tests/state-setters.js
+++ b/src/tests/state-setters.js
@@ -1,0 +1,36 @@
+import {setHeight, setDepth, setPost, getState} from '../state.js';
+
+export function testStateSetters(){
+  const base = {...getState()};
+
+  setHeight(-5);
+  const heightNeg = getState().height === 0;
+  setHeight('abc');
+  const heightNaN = getState().height === 0;
+
+  setDepth(-10);
+  const depthNeg = getState().depth === 0;
+  setDepth('foo');
+  const depthNaN = getState().depth === 0;
+
+  setPost(-1);
+  const postNeg = getState().post === 0;
+  setPost('bar');
+  const postNaN = getState().post === 0;
+
+  // restore original state
+  setHeight(base.height);
+  setDepth(base.depth);
+  setPost(base.post);
+  const state = getState();
+  state.autoHeight = base.autoHeight;
+
+  return [
+    {name:'height negative clamps to 0', pass:heightNeg},
+    {name:'height NaN clamps to 0', pass:heightNaN},
+    {name:'depth negative clamps to 0', pass:depthNeg},
+    {name:'depth NaN clamps to 0', pass:depthNaN},
+    {name:'post negative clamps to 0', pass:postNeg},
+    {name:'post NaN clamps to 0', pass:postNaN}
+  ];
+}


### PR DESCRIPTION
## Summary
- Ensure numeric state setters convert inputs to numbers and clamp to non-negative values
- Add helper to parse numbers and apply to camera, height, depth, and post setters
- Introduce tests verifying clamping behavior for invalid numeric inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add4341188832194804e31453ea97b