### PR TITLE
refactor overlay dimension helper

### DIFF
--- a/src/utils/draw2d.js
+++ b/src/utils/draw2d.js
@@ -27,3 +27,16 @@ export function drawText(ctx, text, x, y, color = '#fff', align = 'center') {
   ctx.fillText(text, sx, sy);
   ctx.restore();
 }
+
+export function drawOverlayDimensions(ctx, bounds, labels) {
+  const scale = ctx.getTransform().a;
+  const text = Array.isArray(labels) ? labels.join(' ') : labels;
+  drawText(
+    ctx,
+    text,
+    bounds.min[0] + 2 / scale,
+    bounds.max[1] + 12 / scale,
+    '#0f0',
+    'left'
+  );
+}

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -10,14 +10,10 @@ export function renderFront(canvas, model, overlays = false) {
     drawRect(ctx, box.x, box.y, box.w, box.h, color);
   });
     if (overlays) {
-      const scale = ctx.getTransform().a;
-      drawText(
+      drawOverlayDimensions(
         ctx,
-        `W:${Math.round(max[0]-min[0])} H:${Math.round(max[1]-min[1])}`,
-        min[0] + 2/scale,
-        max[1] + 12/scale,
-        '#0f0',
-        'left'
+        {min:[min[0], min[1]], max:[max[0], max[1]]},
+        [`W:${Math.round(max[0]-min[0])}`, `H:${Math.round(max[1]-min[1])}`]
       );
     }
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawText, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -11,13 +11,10 @@ export function renderPlan(canvas, model, overlays = false) {
   });
   if (overlays) {
     const scale = ctx.getTransform().a;
-    drawText(
+    drawOverlayDimensions(
       ctx,
-      `W:${Math.round(max[0]-min[0])} D:${Math.round(max[2]-min[2])}`,
-      min[0] + 2/scale,
-      max[2] + 12/scale,
-      '#0f0',
-      'left'
+      {min:[min[0], min[2]], max:[max[0], max[2]]},
+      [`W:${Math.round(max[0]-min[0])}`, `D:${Math.round(max[2]-min[2])}`]
     );
     model.channels.forEach(c => {
       const cx = c.x + c.w / 2;

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -10,14 +10,10 @@ export function renderSide(canvas, model, overlays = false) {
     drawRect(ctx, box.z, box.y, box.d, box.h, color);
   });
   if (overlays) {
-    const scale = ctx.getTransform().a;
-    drawText(
+    drawOverlayDimensions(
       ctx,
-      `D:${Math.round(max[2]-min[2])} H:${Math.round(max[1]-min[1])}`,
-      min[2] + 2/scale,
-      max[1] + 12/scale,
-      '#0f0',
-      'left'
+      {min:[min[2], min[1]], max:[max[2], max[1]]},
+      [`D:${Math.round(max[2]-min[2])}`, `H:${Math.round(max[1]-min[1])}`]
     );
   }
 }


### PR DESCRIPTION
## Summary
- centralize overlay dimension text drawing in `drawOverlayDimensions`
- use helper in plan, front, and side views to keep overlay options intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add518a3048321894652250e3336a3