### PR TITLE
refactor: add overlay dimension helper

### DIFF
--- a/src/utils/draw2d.js
+++ b/src/utils/draw2d.js
@@ -27,3 +27,20 @@ export function drawText(ctx, text, x, y, color = '#fff', align = 'center') {
   ctx.fillText(text, sx, sy);
   ctx.restore();
 }
+
+export function drawOverlayDimensions(ctx, bounds, labels) {
+  const scale = ctx.getTransform().a;
+  const text = labels
+    .map(({label, axis}) => `${label}:${Math.round(bounds.max[axis] - bounds.min[axis])}`)
+    .join(' ');
+  const xAxis = labels[0].axis;
+  const yAxis = labels[1].axis;
+  drawText(
+    ctx,
+    text,
+    bounds.min[xAxis] + 2 / scale,
+    bounds.max[yAxis] + 12 / scale,
+    '#0f0',
+    'left'
+  );
+}

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -10,14 +10,9 @@ export function renderFront(canvas, model, overlays = false) {
     drawRect(ctx, box.x, box.y, box.w, box.h, color);
   });
     if (overlays) {
-      const scale = ctx.getTransform().a;
-      drawText(
-        ctx,
-        `W:${Math.round(max[0]-min[0])} H:${Math.round(max[1]-min[1])}`,
-        min[0] + 2/scale,
-        max[1] + 12/scale,
-        '#0f0',
-        'left'
-      );
+      drawOverlayDimensions(ctx, model.bounds, [
+        {label: 'W', axis: 0},
+        {label: 'H', axis: 1}
+      ]);
     }
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawText, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -10,15 +10,11 @@ export function renderPlan(canvas, model, overlays = false) {
     drawRect(ctx, box.x, box.z, box.w, box.d, color);
   });
   if (overlays) {
+    drawOverlayDimensions(ctx, model.bounds, [
+      {label: 'W', axis: 0},
+      {label: 'D', axis: 2}
+    ]);
     const scale = ctx.getTransform().a;
-    drawText(
-      ctx,
-      `W:${Math.round(max[0]-min[0])} D:${Math.round(max[2]-min[2])}`,
-      min[0] + 2/scale,
-      max[2] + 12/scale,
-      '#0f0',
-      'left'
-    );
     model.channels.forEach(c => {
       const cx = c.x + c.w / 2;
       drawText(ctx, Math.round(c.w).toString(), cx, max[2] + 12/scale, '#0f0');

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,4 +1,4 @@
-import {drawRect, drawText} from '../utils/draw2d.js';
+import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
 import {typeColors} from '../utils/colors.js';
 
@@ -10,14 +10,9 @@ export function renderSide(canvas, model, overlays = false) {
     drawRect(ctx, box.z, box.y, box.d, box.h, color);
   });
   if (overlays) {
-    const scale = ctx.getTransform().a;
-    drawText(
-      ctx,
-      `D:${Math.round(max[2]-min[2])} H:${Math.round(max[1]-min[1])}`,
-      min[2] + 2/scale,
-      max[1] + 12/scale,
-      '#0f0',
-      'left'
-    );
+    drawOverlayDimensions(ctx, model.bounds, [
+      {label: 'D', axis: 2},
+      {label: 'H', axis: 1}
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- add drawOverlayDimensions helper for consistent overlay labels
- use drawOverlayDimensions in plan, front and side views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add518a3048321894652250e3336a3