### PR TITLE
Allow configuring extra bottom beam orientation and lift

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -209,7 +209,14 @@
           <div class="ctl"><label>Bottom lift (mm)</label><input id="bottomLift" value="8" /></div>
           <div class="ctl"><label>Bottom size (mm)</label><input id="bottomSize" value="43" /></div>
         </div>
-        <div class="ctl"><label><input id="extraBottomBeam" type="checkbox" /> Extra bottom beam</label></div>
+        <div class="row">
+          <div class="ctl"><label><input id="extraBottomBeam" type="checkbox" /> Extra bottom beam</label></div>
+          <div class="ctl">
+            <label>Extra beam orientation</label>
+            <select id="extraBottomOrient"><option value="X" selected>Across width</option><option value="Z">Front-to-back</option></select>
+          </div>
+          <div class="ctl"><label>Extra beam lift (mm)</label><input id="extraBottomLift" value="8" /></div>
+        </div>
       </div>
 
       <div class="grp">
@@ -269,7 +276,7 @@ const S = {
   railMode:'edges', // 'edges' | 'centered'
   topSupport:true, topOrient:'X', topDrop:0, topSize:43,
   bottomSupport:true, bottomOrient:'X', bottomLift:8, bottomSize:43,
-  extraBottomBeam:false,
+  extraBottomBeam:false, extraBottomOrient:'X', extraBottomLift:8,
 
   // Bin / opening helper (bins sit on rails by lip)
   binBody:283, binFlange:9.5, binLip:9, binSlack:6,
@@ -377,19 +384,22 @@ function buildModel(){
   }
 
   // Supports (inside frame; avoid overlapping lintels)
-  const addSupport=(where)=>{
-    const on = where==='top'? S.topSupport : S.bottomSupport; if(!on) return;
-    const orient= where==='top'? S.topOrient : S.bottomOrient;
-    const size  = where==='top'? mm(S.topSize) : mm(S.bottomSize);
-    const yPos  = where==='top' ? clamp(P + mm(S.topDrop), P, H-2*P)
-                                 : clamp(H - 2*P - mm(S.bottomLift), P, H-2*P);
+  const addSupport=(where, opts={})=>{
+    const on = opts.on ?? (where==='top'? S.topSupport : S.bottomSupport); if(!on) return;
+    const orient= opts.orient ?? (where==='top'? S.topOrient : S.bottomOrient);
+    const size  = opts.size  ?? (where==='top'? mm(S.topSize) : mm(S.bottomSize));
+    const yPos  = opts.yPos  ?? (where==='top'
+      ? clamp(P + mm(S.topDrop), P, H-2*P)
+      : clamp(H - 2*P - mm(S.bottomLift), P, H-2*P));
     if(orient==='X'){ // across width
       const zMid=(D-size)/2; M.boxes.push({type:'support',x:0,y:yPos,z:zMid,w:W,h:P,d:size});
     }else{            // front-to-back
       const xMid=(W-size)/2; M.boxes.push({type:'support',x:xMid,y:yPos,z:0,w:size,h:P,d:D-P});
     }
   };
-  addSupport('top'); addSupport('bottom'); if(S.extraBottomBeam) addSupport('bottom');
+  addSupport('top');
+  addSupport('bottom');
+  if(S.extraBottomBeam) addSupport('bottom',{orient:S.extraBottomOrient, yPos:clamp(H - 2*P - mm(S.extraBottomLift), P, H-2*P)});
 
   // Rails + bins (lip sits on rail)
   ch.forEach((c)=>{
@@ -762,7 +772,7 @@ function bindInputs(){
   // Supports
   chk('topSupport','topSupport'); sel('topOrient','topOrient'); num('topDrop','topDrop',0,2000); num('topSize','topSize',10,200);
   chk('bottomSupport','bottomSupport'); sel('bottomOrient','bottomOrient'); num('bottomLift','bottomLift',0,2000); num('bottomSize','bottomSize',10,200);
-  chk('extraBottomBeam','extraBottomBeam');
+  chk('extraBottomBeam','extraBottomBeam'); sel('extraBottomOrient','extraBottomOrient'); num('extraBottomLift','extraBottomLift',0,2000);
 
   // Bin helper
   num('binBody','binBody',50,1200, refreshSuggestion); num('binFlange','binFlange',0,40, refreshSuggestion); num('binLip','binLip',0,30);

--- a/src/model.js
+++ b/src/model.js
@@ -31,19 +31,22 @@ export function buildModel(S) {
   }
 
   // Supports
-  const addSupport=(where)=>{
-    const on = where==='top'? S.topSupport : S.bottomSupport; if(!on) return;
-    const orient= where==='top'? S.topOrient : S.bottomOrient;
-    const size  = where==='top'? mm(S.topSize) : mm(S.bottomSize);
-    const yPos  = where==='top' ? clamp(P + mm(S.topDrop), P, H-2*P)
-                                 : clamp(H - 2*P - mm(S.bottomLift), P, H-2*P);
+  const addSupport=(where, opts={})=>{
+    const on = opts.on ?? (where==='top'? S.topSupport : S.bottomSupport); if(!on) return;
+    const orient= opts.orient ?? (where==='top'? S.topOrient : S.bottomOrient);
+    const size  = opts.size  ?? (where==='top'? mm(S.topSize) : mm(S.bottomSize));
+    const yPos  = opts.yPos  ?? (where==='top'
+      ? clamp(P + mm(S.topDrop), P, H-2*P)
+      : clamp(H - 2*P - mm(S.bottomLift), P, H-2*P));
     if(orient==='X'){
       const zMid=(D-size)/2; M.boxes.push({type:'support',x:0,y:yPos,z:zMid,w:W,h:P,d:size});
     }else{
       const xMid=(W-size)/2; M.boxes.push({type:'support',x:xMid,y:yPos,z:0,w:size,h:P,d:D-P});
     }
   };
-  addSupport('top'); addSupport('bottom'); if(S.extraBottomBeam) addSupport('bottom');
+  addSupport('top');
+  addSupport('bottom');
+  if(S.extraBottomBeam) addSupport('bottom', {orient:S.extraBottomOrient, yPos:clamp(H - 2*P - mm(S.extraBottomLift), P, H-2*P)});
 
   // Rails and bins
   ch.forEach((c)=>{

--- a/src/state.js
+++ b/src/state.js
@@ -25,6 +25,8 @@ const state = {
   bottomLift:8,
   bottomSize:43,
   extraBottomBeam:false,
+  extraBottomOrient:'X',
+  extraBottomLift:8,
   binBody:283,
   binFlange:9.5,
   binLip:9,

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -2,10 +2,11 @@ import {testParser} from './parser.js';
 import {testClamp} from './clamp.js';
 import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
+import {testExtraSupport} from './supports.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters()];
+  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport()];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }

--- a/src/tests/supports.js
+++ b/src/tests/supports.js
@@ -1,0 +1,17 @@
+import {buildModel} from '../model.js';
+import {getState} from '../state.js';
+
+export function testExtraSupport(){
+  const S = {...getState(), topSupport:false, extraBottomBeam:true, extraBottomOrient:'Z', extraBottomLift:20};
+  const M = buildModel(S);
+  const supports = M.boxes.filter(b=>b.type==='support');
+  const count = supports.length === 2;
+  const orientations = supports.map(s => s.w === M.W ? 'X' : 'Z');
+  const orientPass = orientations.includes('X') && orientations.includes('Z');
+  const lifts = new Set(supports.map(s=>s.y)).size === 2;
+  return [
+    {name:'extra bottom beam adds second support', pass: count},
+    {name:'extra bottom beam orientation configurable', pass: orientPass},
+    {name:'extra bottom beam lift configurable', pass: lifts}
+  ];
+}


### PR DESCRIPTION
## Summary
- Allow `buildModel` to accept custom support options and use separate orientation/lift for an optional extra bottom beam.
- Expose `extraBottomOrient` and `extraBottomLift` state fields and UI controls so the secondary beam can be positioned independently.
- Add tests verifying an extra bottom beam can differ in orientation and height.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add6e4e7f883218fed10ed0d9febe6