### PR TITLE
feat: improve mm parsing

### DIFF
--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -3,10 +3,11 @@ import {testClamp} from './clamp.js';
 import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
 import {testExtraSupport} from './supports.js';
+import {testMM} from './mm.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport()];
+  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM()];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }

--- a/src/tests/mm.js
+++ b/src/tests/mm.js
@@ -1,0 +1,5 @@
+import {mm} from '../utils/mm.js';
+
+export function testMM(){
+  return [{name:'mm strips suffix', pass:mm('283mm') === 283}];
+}

--- a/src/utils/mm.js
+++ b/src/utils/mm.js
@@ -1,1 +1,5 @@
-export const mm = v => Number(v || 0);
+export const mm = v => {
+  const stripped = String(v).replace(/mm$/i, '');
+  const parsed = Number(stripped);
+  return Number.isFinite(parsed) ? Math.ceil(parsed) : 0;
+};


### PR DESCRIPTION
## Summary
- strip optional `mm` suffix before parsing millimeter values
- add unit test for `mm` utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add96e582c8321a5ced8df2ce9bc50