### PR TITLE
Handle zero-size bounds in fitCanvas

### DIFF
--- a/src/utils/fit.js
+++ b/src/utils/fit.js
@@ -6,7 +6,11 @@ export function fitCanvas(canvas, bounds) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   const width = bounds.max[0] - bounds.min[0];
   const height = bounds.max[1] - bounds.min[1];
-  const scale = Math.min(canvas.width / width, canvas.height / height);
+  const EPSILON = 1e-6;
+  let scale = 1;
+  if (Math.abs(width) > EPSILON && Math.abs(height) > EPSILON) {
+    scale = Math.min(canvas.width / width, canvas.height / height);
+  }
   ctx.setTransform(scale, 0, 0, -scale, -bounds.min[0] * scale, canvas.height + bounds.min[1] * scale);
   return ctx;
 }


### PR DESCRIPTION
## Summary
- Avoid dividing by zero when fitting canvas by defaulting to scale 1 when bounds have zero width or height.
- Use a small epsilon check to prevent infinity transforms.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68addac55768832191e3807e657030cc