### PR TITLE
Fix pinch zoom direction

### DIFF
--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -4,10 +4,11 @@ import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
 import {testExtraSupport} from './supports.js';
 import {testMM} from './mm.js';
+import {testPinchZoom} from './pinch.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM()];
+  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM(), ...testPinchZoom()];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }

--- a/src/tests/pinch.js
+++ b/src/tests/pinch.js
@@ -1,0 +1,37 @@
+import {init3dControls, render3d} from '../views/view3d.js';
+import {getState} from '../state.js';
+
+export function testPinchZoom(){
+  const listeners = {};
+  const canvas = {
+    clientWidth: 100,
+    clientHeight: 100,
+    width: 100,
+    height: 100,
+    getContext: () => ({
+      clearRect() {}, beginPath() {}, moveTo() {}, lineTo() {}, closePath() {},
+      fill() {}, stroke() {}, fillText() {},
+      lineWidth: 0, fillStyle: '', strokeStyle: '', font: ''
+    }),
+    addEventListener: (type, handler) => {listeners[type] = handler;},
+    setPointerCapture() {}
+  };
+
+  const model = {boxes: [], bounds: {min: [0,0,0], max: [0,0,0]}};
+  render3d(canvas, model);
+  init3dControls(canvas);
+
+  const p1 = {pointerId: 1, clientX: 0, clientY: 0};
+  const p2 = {pointerId: 2, clientX: 100, clientY: 0};
+  listeners['pointerdown'](p1);
+  listeners['pointerdown'](p2);
+
+  listeners['pointermove']({pointerId: 2, clientX: 200, clientY: 0});
+
+  const zoom = getState().zoom;
+
+  listeners['pointerup'](p1);
+  listeners['pointerup']({pointerId: 2, clientX: 200, clientY: 0});
+
+  return [{name: 'pinch zoom increases when fingers spread', pass: zoom > 1}];
+}

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -125,7 +125,7 @@ export function init3dControls(canvas){
     }else if(pointers.size===2){
       const [p1,p2]=Array.from(pointers.values());
       const d=dist(p1,p2);
-      camState.zoom=clamp(pinchZoom*(pinchDist/d),0.5,3);
+      camState.zoom=clamp(pinchZoom*(d/pinchDist),0.5,3);
       setCamera(camState,false);
       render3d(canvasRef, modelRef, overlayRef);
     }


### PR DESCRIPTION
## Summary
- Make pinch-zoom gestures intuitive by zooming in when fingers move apart
- Add interaction test to ensure pinch zoom increases with finger spread

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68addb5d869083218e2884420fbd1958