### PR TITLE
Handle row overflow when height insufficient

### DIFF
--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -4,10 +4,11 @@ import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
 import {testExtraSupport} from './supports.js';
 import {testMM} from './mm.js';
+import {testLevels} from './levels.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM()];
+  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM(), ...testLevels()];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }

--- a/src/tests/levels.js
+++ b/src/tests/levels.js
@@ -1,0 +1,13 @@
+import {buildModel} from '../model.js';
+import {getState} from '../state.js';
+
+export function testLevels(){
+  const base = getState();
+  const S = {...base, autoHeight:false, height:300};
+  const M = buildModel(S);
+  return [{
+    name:'row overflow stops extra levels',
+    pass:M.rowOverflow && M.levels.length === 1
+  }];
+}
+

--- a/src/utils/computeLevels.js
+++ b/src/utils/computeLevels.js
@@ -7,12 +7,13 @@ export function computeLevels(S){
   const out = [];
   let overflow = false;
   for(const r of S.rows){
-    if(!S.autoHeight && y > S.height - P){
+    const h = mm(r.height);
+    if(!S.autoHeight && (y > S.height - P || y + h > S.height - P)){
       overflow = true;
       break;
     }
     out.push(clamp(y,0,(S.autoHeight?1e9:S.height)-P));
-    y += mm(r.height) + P + mm(r.gap);
+    y += h + P + mm(r.gap);
   }
   return {levels:out, rowOverflow:overflow};
 }


### PR DESCRIPTION
## Summary
- Prevent rows from exceeding manual height by checking row bottom against available space
- Add test ensuring overflow is reported when a row cannot fit within height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addb9c54f48321a9e9fdc9668707a7