### PR TITLE
Respect bin slack in bin sizing

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -409,7 +409,7 @@ function buildModel(){
       if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
       if(S.showBins && allowBottom){
         const row=S.rows[idx]||{};
-        const bodyW=Math.min(mm(S.binBody), c.w-2);
+        const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w - mm(S.binSlack)));
         const overall= bodyW + 2*mm(S.binFlange);
         const bx=c.x + (c.w - overall)/2;
         const lip=mm(S.binLip);

--- a/src/model.js
+++ b/src/model.js
@@ -56,7 +56,7 @@ export function buildModel(S) {
       if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
       if(S.showBins && allowBottom){
         const row=S.rows[idx]||{};
-        const bodyW=Math.min(mm(S.binBody), c.w-2);
+        const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w - mm(S.binSlack)));
         const overall= bodyW + 2*mm(S.binFlange);
         const bx=c.x + (c.w - overall)/2;
         const lip=mm(S.binLip);

--- a/src/tests/bin-slack.js
+++ b/src/tests/bin-slack.js
@@ -1,0 +1,15 @@
+import {buildModel} from '../model.js';
+import {getState} from '../state.js';
+import {mm} from '../utils/mm.js';
+
+export function testBinSlack(){
+  const base = getState();
+  const opening = Math.ceil(mm(base.binBody) + 2*mm(base.binFlange) + mm(base.binSlack));
+  const S = {...base, patternText:`${base.post},${opening},${base.post}`};
+  const M = buildModel(S);
+  const channelWidth = M.channels[0].w;
+  const binBox = M.boxes.find(b=>b.type==='bin');
+  const diff = channelWidth - binBox.w;
+  return [{name:'bin slack respected', pass: diff === mm(S.binSlack)}];
+}
+

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -4,10 +4,19 @@ import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
 import {testExtraSupport} from './supports.js';
 import {testMM} from './mm.js';
+import {testBinSlack} from './bin-slack.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
-  const results = [...testParser(), ...testClamp(), ...testCounts(), ...testStateSetters(), ...testExtraSupport(), ...testMM()];
+  const results = [
+    ...testParser(),
+    ...testClamp(),
+    ...testCounts(),
+    ...testStateSetters(),
+    ...testExtraSupport(),
+    ...testMM(),
+    ...testBinSlack()
+  ];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;
 }


### PR DESCRIPTION
## Summary
- Account for bin clearance slack when computing bin widths
- Mirror bin slack logic in HTML demo
- Add regression test confirming slack is honored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addb4d40948321817e4e2c2e28c07d