### PR TITLE
Refactor view3d to use shared clamp util

### DIFF
--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,5 +1,6 @@
 import {typeColors} from '../utils/colors.js';
 import {getState, setCamera} from '../state.js';
+import {clamp} from '../utils/math.js';
 
 const camState = {yaw:0.5, pitch:0.3, zoom:1};
 let canvasRef, modelRef, overlayRef;
@@ -82,9 +83,6 @@ export function render3d(canvas, model, overlays=false){
     ctx.fillText(`W:${Math.round(width)} H:${Math.round(height)} D:${Math.round(depth)}`,10,20);
   }
 }
-
-function clamp(v,min,max){return v<min?min:v>max?max:v;}
-
 export function init3dControls(canvas){
   canvas.addEventListener('dblclick',()=>{
     camState.yaw=0.5; camState.pitch=0.3; camState.zoom=1;


### PR DESCRIPTION
## Summary
- reuse shared `clamp` helper from utils in 3d view
- remove local `clamp` implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade1a6c3048321a783578d9bb118d7