### PR TITLE
Remove bundled test import from main build

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,6 @@ import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
 import {render3d, init3dControls} from './views/view3d.js';
-import './tests/index.js';
 
 function showRowOverflowWarning(){
   let banner=document.getElementById('rowoverflow-warning');


### PR DESCRIPTION
## Summary
- stop importing test suite in main entry point to keep production bundle lean

## Testing
- `npm test`
- `npm run build`
- `rg runTests dist/bundle.js`


------
https://chatgpt.com/codex/tasks/task_e_68ade610de648321ad717d63841c6d69