### PR TITLE
Respect bin slack in model calculations

### DIFF
--- a/rail-bin-builder.html
+++ b/rail-bin-builder.html
@@ -409,8 +409,9 @@ function buildModel(){
       if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
       if(S.showBins && allowBottom){
         const row=S.rows[idx]||{};
-        const bodyW=Math.min(mm(S.binBody), c.w-2);
-        const overall= bodyW + 2*mm(S.binFlange);
+        const slack = mm(S.binSlack);
+        const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w-2-slack));
+        const overall= bodyW + 2*mm(S.binFlange) + slack;
         const bx=c.x + (c.w - overall)/2;
         const lip=mm(S.binLip);
         const binH=mm(row.height ?? S.binHeightDefault);

--- a/src/model.js
+++ b/src/model.js
@@ -56,8 +56,9 @@ export function buildModel(S) {
       if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
       if(S.showBins && allowBottom){
         const row=S.rows[idx]||{};
-        const bodyW=Math.min(mm(S.binBody), c.w-2);
-        const overall= bodyW + 2*mm(S.binFlange);
+        const slack = mm(S.binSlack);
+        const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w-2-slack));
+        const overall= bodyW + 2*mm(S.binFlange) + slack;
         const bx=c.x + (c.w - overall)/2;
         const lip=mm(S.binLip);
         const binH=mm(row.height ?? S.binHeightDefault);

--- a/src/tests/bin-slack.js
+++ b/src/tests/bin-slack.js
@@ -1,0 +1,16 @@
+import {buildModel} from '../model.js';
+import {getState} from '../state.js';
+import {channels} from '../utils/channels.js';
+import {mm} from '../utils/mm.js';
+
+export function testBinSlack(){
+  const S = {...getState(), binSlack:20};
+  const M = buildModel(S);
+  const bin = M.boxes.find(b=>b.type==='bin');
+  const chWidth = channels(S)[0].w;
+  const expectedBody = Math.min(mm(S.binBody), Math.max(0, chWidth - 2 - mm(S.binSlack)));
+  const expectedOverall = expectedBody + 2*mm(S.binFlange) + mm(S.binSlack);
+  const pass = Math.abs(bin.w - expectedOverall) < 1e-6;
+  return [{name:'bin width includes slack', pass}];
+}
+

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -6,6 +6,7 @@ import {testExtraSupport} from './supports.js';
 import {testMM} from './mm.js';
 import {testLevels} from './levels.js';
 import {testPinchZoom} from './pinch-zoom.js';
+import {testBinSlack} from './bin-slack.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
@@ -17,7 +18,8 @@ export function runTests(){
     ...testExtraSupport(),
     ...testMM(),
     ...testLevels(),
-    ...testPinchZoom()
+    ...testPinchZoom(),
+    ...testBinSlack()
   ];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;


### PR DESCRIPTION
## Summary
- Include configurable slack in bin width/position calculations so bins fit with extra clearance.
- Mirror slack logic in the demo builder UI for accurate previews.
- Add unit test verifying bin width accounts for configured slack.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade26086d0832197d9a7b0ffdeb553