### PR TITLE
Continue rendering when rows overflow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,10 +39,12 @@ function hideRowOverflowWarning(){
 function render(){
   const model = buildModel(getState());
   if(model.rowOverflow){
+    // Show the warning banner but continue rendering with the
+    // clamped levels provided by the model.
     showRowOverflowWarning();
-    return;
+  }else{
+    hideRowOverflowWarning();
   }
-  hideRowOverflowWarning();
   const o = getState().showOverlays;
   const frontEl = document.getElementById('front');
   if (frontEl) {


### PR DESCRIPTION
## Summary
- Keep rendering the model even when row count exceeds available height
- Display an overflow warning banner while rendering with clamped levels

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade93e65148321bacbd0657ae87bf0