### PR TITLE
Ensure bin depth is never negative

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -64,7 +64,7 @@ export function buildModel(S) {
         const binH=mm(row.height ?? S.binHeightDefault);
         const over=mm(row.overhang ?? 0);
         const gap=mm(row.gap ?? 0);
-        const dHere= Math.min(D + Math.max(0,over), D + over);
+        const dHere = Math.max(0, D + over);
         const yTop = Math.max(0, y + P - lip);
         M.boxes.push({type:'bin',x:bx,y:yTop,z:0,w:overall,h:binH,d:dHere,gap});
       }

--- a/src/tests/bin-slack.js
+++ b/src/tests/bin-slack.js
@@ -4,13 +4,28 @@ import {channels} from '../utils/channels.js';
 import {mm} from '../utils/mm.js';
 
 export function testBinSlack(){
-  const S = {...getState(), binSlack:20};
-  const M = buildModel(S);
-  const bin = M.boxes.find(b=>b.type==='bin');
-  const chWidth = channels(S)[0].w;
-  const expectedBody = Math.min(mm(S.binBody), Math.max(0, chWidth - 2 - mm(S.binSlack)));
-  const expectedOverall = expectedBody + 2*mm(S.binFlange) + mm(S.binSlack);
-  const pass = Math.abs(bin.w - expectedOverall) < 1e-6;
-  return [{name:'bin width includes slack', pass}];
+  const results = [];
+
+  {
+    const S = {...getState(), binSlack:20};
+    const M = buildModel(S);
+    const bin = M.boxes.find(b=>b.type==='bin');
+    const chWidth = channels(S)[0].w;
+    const expectedBody = Math.min(mm(S.binBody), Math.max(0, chWidth - 2 - mm(S.binSlack)));
+    const expectedOverall = expectedBody + 2*mm(S.binFlange) + mm(S.binSlack);
+    const pass = Math.abs(bin.w - expectedOverall) < 1e-6;
+    results.push({name:'bin width includes slack', pass});
+  }
+
+  {
+    const rows = getState().rows.map(r=>({...r, overhang:-1000}));
+    const S = {...getState(), rows};
+    const M = buildModel(S);
+    const bin = M.boxes.find(b=>b.type==='bin');
+    const pass = bin.d === 0;
+    results.push({name:'bin depth not negative with large negative overhang', pass});
+  }
+
+  return results;
 }
 


### PR DESCRIPTION
## Summary
- Prevent negative bin depths by clamping to zero in model generation.
- Add regression test verifying bins stay at zero depth when given large negative overhang.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bacc39539c832194902bd3409129ca