### PR TITLE
Ensure bin depth never negative

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -64,7 +64,7 @@ export function buildModel(S) {
         const binH=mm(row.height ?? S.binHeightDefault);
         const over=mm(row.overhang ?? 0);
         const gap=mm(row.gap ?? 0);
-        const dHere= Math.min(D + Math.max(0,over), D + over);
+        const dHere = Math.max(0, D + over);
         const yTop = Math.max(0, y + P - lip);
         M.boxes.push({type:'bin',x:bx,y:yTop,z:0,w:overall,h:binH,d:dHere,gap});
       }

--- a/src/tests/bin-slack.js
+++ b/src/tests/bin-slack.js
@@ -11,6 +11,20 @@ export function testBinSlack(){
   const expectedBody = Math.min(mm(S.binBody), Math.max(0, chWidth - 2 - mm(S.binSlack)));
   const expectedOverall = expectedBody + 2*mm(S.binFlange) + mm(S.binSlack);
   const pass = Math.abs(bin.w - expectedOverall) < 1e-6;
-  return [{name:'bin width includes slack', pass}];
+
+  // Large negative overhang shouldn't produce a negative bin depth
+  const T = {
+    ...getState(),
+    bottomRowRails: true,
+    rows: [{overhang: -1000}]
+  };
+  const M2 = buildModel(T);
+  const bin2 = M2.boxes.find(b=>b.type==='bin');
+  const depthPass = bin2.d === 0;
+
+  return [
+    {name:'bin width includes slack', pass},
+    {name:'negative overhang yields zero depth', pass: depthPass}
+  ];
 }
 


### PR DESCRIPTION
## Summary
- Clamp bin depth to zero when bin overhang is negative
- Add regression test for negative overhang handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bacc39539c832194902bd3409129ca