### PR TITLE
Reuse precomputed segments in channel calculations

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -8,9 +8,9 @@ import {autoHeightFromRows} from './utils/autoHeight.js';
 
 export function buildModel(S) {
   const P = S.post;
-  const ch = channels(S);
-  const {levels:L, rowOverflow} = computeLevels(S);
   const seg = segments(S);
+  const ch = channels(S, seg);
+  const {levels:L, rowOverflow} = computeLevels(S);
   const W = seg.reduce((a,b)=>a+b,0);
   const H = S.autoHeight ? autoHeightFromRows(S) : S.height;
   const D = S.depth;

--- a/src/tests/bin-slack.js
+++ b/src/tests/bin-slack.js
@@ -1,6 +1,7 @@
 import {buildModel} from '../model.js';
 import {getState} from '../state.js';
 import {channels} from '../utils/channels.js';
+import {segments} from '../utils/segments.js';
 import {mm} from '../utils/mm.js';
 
 export function testBinSlack(){
@@ -10,7 +11,8 @@ export function testBinSlack(){
     const S = {...getState(), binSlack:20};
     const M = buildModel(S);
     const bin = M.boxes.find(b=>b.type==='bin');
-    const chWidth = channels(S)[0].w;
+    const seg = segments(S);
+    const chWidth = channels(S, seg)[0].w;
     const expectedBody = Math.min(mm(S.binBody), Math.max(0, chWidth - 2 - mm(S.binSlack)));
     const expectedOverall = expectedBody + 2*mm(S.binFlange) + mm(S.binSlack);
     const pass = Math.abs(bin.w - expectedOverall) < 1e-6;

--- a/src/utils/channels.js
+++ b/src/utils/channels.js
@@ -1,7 +1,7 @@
 import {segments} from './segments.js';
 
-export function channels(S){
-  const seg = segments(S); const P=S.post; let x=0; const out=[];
+export function channels(S, seg = segments(S)){
+  const P=S.post; let x=0; const out=[];
   for(const s of seg){
     if(s!==P) out.push({x, w:s});
     x += s;


### PR DESCRIPTION
## Summary
- allow `channels` to accept an optional precomputed segment list
- reuse precomputed segments when building models so channels and posts share the same data
- adjust the bin slack test to pass the precomputed segments into `channels`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd7e463948321891de2462a8b8377