### PR TITLE
Refactor level metrics sharing

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -10,9 +10,10 @@ export function buildModel(S) {
   const P = S.post;
   const seg = segments(S);
   const ch = channels(S, seg);
-  const {levels:L, rowOverflow} = computeLevels(S);
+  const levelData = computeLevels(S);
+  const {levels:L, rowOverflow} = levelData;
   const W = seg.reduce((a,b)=>a+b,0);
-  const H = S.autoHeight ? autoHeightFromRows(S) : S.height;
+  const H = S.autoHeight ? autoHeightFromRows(S, levelData) : S.height;
   const D = S.depth;
   const R = Math.min(S.runnerDepth, S.depth);
   const M = {W,H,D,P,channels:ch,levels:L,rowOverflow,boxes:[]};

--- a/src/utils/autoHeight.js
+++ b/src/utils/autoHeight.js
@@ -1,9 +1,18 @@
 import {mm} from './mm.js';
+import {computeLevels} from './computeLevels.js';
 
-export function autoHeightFromRows(S){
+export function autoHeightFromRows(S, shared){
+  const computed = shared ?? computeLevels(S);
+  const rows = computed.rows ?? [];
+  let heights = 0;
+  let gaps = 0;
+  for(const row of rows){
+    heights += row.heightMm ?? 0;
+    gaps += row.gapMm ?? 0;
+  }
   const P = S.post;
-  const lintels = P * (S.rows.length + 1);
-  const heights = S.rows.reduce((a,r)=>a + mm(r.height),0);
-  const gaps = S.rows.reduce((a,r)=>a + mm(r.gap),0);
-  return lintels + mm(S.bottomClear) + mm(S.topClear) + heights + gaps;
+  const lintels = P * ((rows.length || S.rows.length) + 1);
+  const bottomClear = computed.bottomClearMm ?? mm(S.bottomClear);
+  const topClear = mm(S.topClear);
+  return lintels + bottomClear + topClear + heights + gaps;
 }

--- a/src/utils/computeLevels.js
+++ b/src/utils/computeLevels.js
@@ -3,17 +3,31 @@ import {clamp} from './math.js';
 
 export function computeLevels(S){
   const P = S.post;
-  let y = P + mm(S.bottomClear);
-  const out = [];
+  const bottomClearMm = mm(S.bottomClear);
+  let y = P + bottomClearMm;
+  const maxLevel = (S.autoHeight ? 1e9 : S.height) - P;
+  const levels = [];
+  const rows = [];
   let overflow = false;
-  for(const r of S.rows){
-    const h = mm(r.height);
-    if(!S.autoHeight && (y > S.height - P || y + h > S.height - P)){
+
+  for (const r of S.rows){
+    const heightMm = mm(r.height);
+    const gapMm = mm(r.gap);
+    const rowInfo = {heightMm, gapMm};
+
+    if(!overflow && !S.autoHeight && (y > S.height - P || y + heightMm > S.height - P)){
       overflow = true;
-      break;
     }
-    out.push(clamp(y,0,(S.autoHeight?1e9:S.height)-P));
-    y += h + P + mm(r.gap);
+
+    if(!overflow){
+      const level = clamp(y, 0, maxLevel);
+      rowInfo.level = level;
+      levels.push(level);
+      y += heightMm + P + gapMm;
+    }
+
+    rows.push(rowInfo);
   }
-  return {levels:out, rowOverflow:overflow};
+
+  return {levels, rowOverflow:overflow, rows, bottomClearMm};
 }


### PR DESCRIPTION
## Summary
- extend `computeLevels` to retain per-row millimeter heights and gaps alongside level placement metadata
- refactor `autoHeightFromRows` to reuse the shared measurements instead of recalculating conversions
- update `buildModel` to pass the shared level data through so auto-height uses the cached values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf5919b848321b2400bb59ceb67fd