### PR TITLE
Restructure layout into two-column shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,27 +8,41 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <form id="controls">
-      <label>Height <input id="height-input" type="number" /></label>
-      <label>Depth <input id="depth-input" type="number" /></label>
-      <label>Post <input id="post-input" type="number" /></label>
-      <label>Pattern <input id="pattern-input" type="text" /></label>
-      <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
-      <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
-      <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
-    </form>
-    <div id="view-controls">
-      <button data-view="quad">Quad</button>
-      <button data-view="three">3D</button>
-      <button data-view="plan">Plan</button>
-      <button data-view="front">Front</button>
-      <button data-view="side">Side</button>
-    </div>
-    <div id="views">
-      <canvas id="front"></canvas>
-      <canvas id="side"></canvas>
-      <canvas id="plan"></canvas>
-      <canvas id="three"></canvas>
+    <div class="app">
+      <div class="views" id="views">
+        <div class="view" data-view="front">
+          <canvas id="front"></canvas>
+        </div>
+        <div class="view" data-view="side">
+          <canvas id="side"></canvas>
+        </div>
+        <div class="view" data-view="plan">
+          <canvas id="plan"></canvas>
+        </div>
+        <div class="view" data-view="three">
+          <canvas id="three"></canvas>
+        </div>
+      </div>
+      <div class="panel">
+        <div id="view-controls">
+          <button data-view="quad">Quad</button>
+          <button data-view="three">3D</button>
+          <button data-view="plan">Plan</button>
+          <button data-view="front">Front</button>
+          <button data-view="side">Side</button>
+        </div>
+        <div id="controlsRoot">
+          <form id="controls">
+            <label>Height <input id="height-input" type="number" /></label>
+            <label>Depth <input id="depth-input" type="number" /></label>
+            <label>Post <input id="post-input" type="number" /></label>
+            <label>Pattern <input id="pattern-input" type="text" /></label>
+            <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
+            <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
+            <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
+          </form>
+        </div>
+      </div>
     </div>
 
     <script type="module" src="./src/main.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -73,13 +73,24 @@ function render(){
 
   const vm = getState().viewMode;
   document.body.classList.toggle('single', vm !== 'quad');
-  const canvases = document.querySelectorAll('#views canvas');
-  if (canvases.length === 0) {
-    console.warn('No canvases found under #views.');
+  const viewsRoot = document.getElementById('views');
+  if (!viewsRoot) {
+    console.warn('Element #views not found. Skipping view visibility updates.');
   } else {
-    canvases.forEach(c=>{
-      c.classList.toggle('active', vm === 'quad' ? true : c.id === vm);
-    });
+    const viewPanels = viewsRoot.querySelectorAll('.view');
+    if (viewPanels.length === 0) {
+      console.warn('No .view containers found under #views.');
+    } else {
+      viewPanels.forEach(panel=>{
+        const canvas = panel.querySelector('canvas');
+        const panelView = panel.dataset.view || (canvas && canvas.id);
+        const isActive = vm === 'quad' ? true : panelView === vm;
+        panel.classList.toggle('active', Boolean(isActive));
+        if (canvas) {
+          canvas.classList.toggle('active', Boolean(isActive));
+        }
+      });
+    }
   }
 }
 
@@ -150,16 +161,21 @@ function init() {
     });
   }
 
-  const canvases = document.querySelectorAll('#views canvas');
-  if (canvases.length === 0) {
-    console.warn('No canvases found under #views.');
+  const viewsRoot = document.getElementById('views');
+  if (!viewsRoot) {
+    console.warn('Element #views not found. Skipping canvas event binding.');
   } else {
-    canvases.forEach(cvs=>{
-      cvs.addEventListener('click', ()=>{
-        const vm = getState().viewMode;
-        setViewMode(vm === 'quad' ? cvs.id : 'quad');
+    const canvases = viewsRoot.querySelectorAll('canvas');
+    if (canvases.length === 0) {
+      console.warn('No canvases found under #views.');
+    } else {
+      canvases.forEach(cvs=>{
+        cvs.addEventListener('click', ()=>{
+          const vm = getState().viewMode;
+          setViewMode(vm === 'quad' ? cvs.id : 'quad');
+        });
       });
-    });
+    }
   }
 
   const threeEl = document.getElementById('three');

--- a/styles.css
+++ b/styles.css
@@ -6,46 +6,91 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
+  background: #111;
+  color: #f7f7f8;
 }
 
-#controls,
-#view-controls,
-#views {
-  margin: var(--space);
-}
-
-#controls {
+.app {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: var(--space);
-  padding: var(--space);
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 1fr);
+  min-height: 100vh;
+  background: #111;
 }
 
-#controls label {
+.views {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: calc(var(--space) * 1.5);
+  padding: calc(var(--space) * 2);
+  min-width: 0;
+  min-height: 0;
+}
+
+.view {
+  position: relative;
+  background: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.panel {
+  background: #f7f7f8;
+  color: #111;
+  padding: calc(var(--space) * 2);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: calc(var(--space) * 2);
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 #view-controls {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space);
-  padding: var(--space);
+  align-items: center;
 }
 
 #view-controls button {
-  padding: calc(var(--space) / 2) var(--space);
+  padding: calc(var(--space) / 2) calc(var(--space) * 1.25);
+  border-radius: 999px;
+  border: 1px solid #ccc;
+  background: #fff;
+  color: #111;
+  cursor: pointer;
 }
 
-#views {
-  display: grid;
+#controlsRoot {
+  display: flex;
+  flex-direction: column;
   gap: var(--space);
-  padding: var(--space);
-  grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: repeat(2, 50vh);
+}
+
+#controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space);
+  padding: calc(var(--space) * 1.5);
+  border-radius: 12px;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+}
+
+#controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 canvas {
@@ -55,29 +100,40 @@ canvas {
   display: block;
 }
 
-@media (max-width: 768px) {
-  #views {
+@media (max-width: 960px) {
+  .app {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(4, 50vh);
+  }
+
+  .panel {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .views {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, minmax(0, 40vh));
   }
 }
 
 @media (max-width: 480px) {
   #view-controls {
     flex-direction: column;
+    align-items: stretch;
   }
 }
 
 body.single #views {
   grid-template-columns: 1fr;
-  grid-template-rows: 100vh;
+  grid-template-rows: 1fr;
 }
 
-body.single #views canvas {
+body.single #views .view {
   display: none;
 }
 
-body.single #views canvas.active {
+body.single #views .view.active {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- wrap the page in a two-column `.app` container with dedicated `.views` and `.panel` regions and move the control form under `#controlsRoot`
- extend the stylesheet with layout rules for the new containers, refreshed spacing, and single-view visibility helpers
- update the main script to work with the new view wrappers when toggling modes and binding canvas interactions

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cc0861cc188321b1c98db45672d0aa