### PR TITLE
Add view HUD overlays and 3D fit control

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,16 +11,25 @@
     <div class="app">
       <div class="views" id="views">
         <div class="view" data-view="front">
+          <div class="hud">FRONT / Elevation (X×Y)</div>
           <canvas id="front"></canvas>
+          <div class="legend">Overall W/H, openings, clearances</div>
         </div>
         <div class="view" data-view="side">
+          <div class="hud">SIDE / Elevation (Z×Y)</div>
           <canvas id="side"></canvas>
+          <div class="legend">Depth &amp; rail length</div>
         </div>
         <div class="view" data-view="plan">
+          <div class="hud">TOP / Plan (X×Z)</div>
           <canvas id="plan"></canvas>
+          <div class="legend">Openings &amp; rail footprints</div>
         </div>
         <div class="view" data-view="three">
+          <div class="hud">3D</div>
+          <button class="fit" id="fit-three" type="button">Fit view</button>
           <canvas id="three"></canvas>
+          <div class="legend">Posts: pink · Lintels: gray · Rails: blue · Supports: orange · Bins: red</div>
         </div>
       </div>
       <div class="panel">

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
 import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
-import {render3d, init3dControls} from './views/view3d.js';
+import {render3d, init3dControls, reset3dCamera} from './views/view3d.js';
 
 function showRowOverflowWarning(){
   let banner=document.getElementById('rowoverflow-warning');
@@ -183,6 +183,13 @@ function init() {
     init3dControls(threeEl);
   } else {
     console.warn('Element #three not found. Skipping 3D controls initialization.');
+  }
+
+  const fitThreeButton = document.getElementById('fit-three');
+  if (fitThreeButton) {
+    fitThreeButton.addEventListener('click', () => reset3dCamera());
+  } else {
+    console.warn('#fit-three not found. Skipping 3D fit button wiring.');
   }
 
   subscribe(render);

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -2,7 +2,8 @@ import {typeColors} from '../utils/colors.js';
 import {getState, setCamera} from '../state.js';
 import {clamp} from '../utils/math.js';
 
-const camState = {yaw:0.5, pitch:0.3, zoom:1};
+const defaultCamera = {yaw:0.5, pitch:0.3, zoom:1};
+const camState = {...defaultCamera};
 let canvasRef, modelRef, overlayRef;
 
 function shadeColor(hex, factor){
@@ -83,11 +84,17 @@ export function render3d(canvas, model, overlays=false){
     ctx.fillText(`W:${Math.round(width)} H:${Math.round(height)} D:${Math.round(depth)}`,10,20);
   }
 }
+
+export function reset3dCamera({notify=true}={}){
+  Object.assign(camState, defaultCamera);
+  setCamera({...camState}, notify);
+  if(!notify && canvasRef){
+    render3d(canvasRef, modelRef, overlayRef);
+  }
+}
 export function init3dControls(canvas){
   canvas.addEventListener('dblclick',()=>{
-    camState.yaw=0.5; camState.pitch=0.3; camState.zoom=1;
-    setCamera(camState,false);
-    render3d(canvasRef, modelRef, overlayRef);
+    reset3dCamera({notify:false});
   });
   canvas.addEventListener('wheel',e=>{
     camState.zoom=clamp(camState.zoom+(e.deltaY>0?0.1:-0.1),0.5,3);

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,50 @@ body {
   min-height: 0;
 }
 
+.hud {
+  position: absolute;
+  left: 0.5rem;
+  top: 0.5rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 12px;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  pointer-events: none;
+}
+
+.fit {
+  position: absolute;
+  right: 0.5rem;
+  top: 0.5rem;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 12px;
+  padding: 0.24rem 0.5rem;
+  border: none;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.fit:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.legend {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 11px;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  max-width: min(260px, 80%);
+  pointer-events: none;
+}
+
 .panel {
   background: #f7f7f8;
   color: #111;


### PR DESCRIPTION
## Summary
- add HUD captions and legends to each canvas view container
- style HUD, legend, and fit overlay elements for consistent placement
- wire up a 3D fit control that resets the camera to the default framing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc11d336948321a27dbac62a414174