### PR TITLE
Add toolbar view controls and cut list panel toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,15 @@
         </div>
       </div>
       <div class="panel">
-        <div id="view-controls">
-          <button data-view="quad">Quad</button>
-          <button data-view="three">3D</button>
-          <button data-view="plan">Plan</button>
-          <button data-view="front">Front</button>
-          <button data-view="side">Side</button>
+        <div class="toolbar">
+          <span>View:</span>
+          <button class="seg" type="button" data-view="quad">Quad</button>
+          <button class="seg" type="button" data-view="three">3D</button>
+          <button class="seg" type="button" data-view="plan">Plan</button>
+          <button class="seg" type="button" data-view="front">Front</button>
+          <button class="seg" type="button" data-view="side">Side</button>
+          <button class="pill" type="button" id="toggleQuad3D">Quad ⇄ 3D</button>
+          <button class="pill" type="button" id="toggleCutList">Cut List</button>
         </div>
         <div id="controlsRoot">
           <form id="controls">
@@ -41,6 +44,13 @@
             <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
             <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
           </form>
+        </div>
+        <div id="cutListPanel" hidden>
+          <div class="cut-list-header">
+            <h2>Cut List</h2>
+            <button class="pill" type="button" id="closeCutList">Close</button>
+          </div>
+          <p id="cutListPlaceholder">Cut list details will appear here.</p>
         </div>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -92,6 +92,19 @@ function render(){
       });
     }
   }
+
+  const viewButtons = document.querySelectorAll('.toolbar .seg[data-view]');
+  viewButtons.forEach(btn=>{
+    const isActive = btn.dataset.view === vm;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
+  });
+
+  const toggleQuad3DButton = document.getElementById('toggleQuad3D');
+  if (toggleQuad3DButton) {
+    const isThreeDee = vm === 'three';
+    toggleQuad3DButton.setAttribute('aria-pressed', String(isThreeDee));
+  }
 }
 
 function init() {
@@ -152,13 +165,63 @@ function init() {
     console.warn('#overlay-toggle not found. Skipping overlay toggle setup.');
   }
 
-  const viewButtons = document.querySelectorAll('#view-controls button');
+  const viewButtons = document.querySelectorAll('.toolbar .seg[data-view]');
   if (viewButtons.length === 0) {
-    console.warn('No buttons found under #view-controls.');
+    console.warn('No segmented view buttons found.');
   } else {
     viewButtons.forEach(btn=>{
       btn.addEventListener('click', ()=>setViewMode(btn.dataset.view));
     });
+  }
+
+  const toggleQuad3DButton = document.getElementById('toggleQuad3D');
+  if (toggleQuad3DButton) {
+    toggleQuad3DButton.addEventListener('click', ()=>{
+      const vm = getState().viewMode;
+      setViewMode(vm === 'three' ? 'quad' : 'three');
+    });
+  } else {
+    console.warn('#toggleQuad3D not found. Skipping Quad ⇄ 3D toggle setup.');
+  }
+
+  const cutListPanel = document.getElementById('cutListPanel');
+  const toggleCutListButton = document.getElementById('toggleCutList');
+  const closeCutListButton = document.getElementById('closeCutList');
+
+  const setCutListOpen = open=>{
+    if (!cutListPanel) {
+      console.warn('#cutListPanel not found. Cannot toggle cut list panel.');
+      return;
+    }
+    if (open) {
+      cutListPanel.removeAttribute('hidden');
+    } else {
+      cutListPanel.setAttribute('hidden', '');
+    }
+    if (toggleCutListButton) {
+      toggleCutListButton.setAttribute('aria-expanded', String(open));
+    }
+  };
+
+  if (toggleCutListButton) {
+    const isOpen = Boolean(cutListPanel && !cutListPanel.hasAttribute('hidden'));
+    toggleCutListButton.setAttribute('aria-expanded', String(isOpen));
+    toggleCutListButton.addEventListener('click', ()=>{
+      if (!cutListPanel) {
+        console.warn('#cutListPanel not found. Cannot toggle cut list panel.');
+        return;
+      }
+      const shouldOpen = cutListPanel.hasAttribute('hidden');
+      setCutListOpen(shouldOpen);
+    });
+  } else {
+    console.warn('#toggleCutList not found. Skipping cut list toggle setup.');
+  }
+
+  if (closeCutListButton) {
+    closeCutListButton.addEventListener('click', ()=>setCutListOpen(false));
+  } else if (cutListPanel) {
+    console.warn('#closeCutList not found. Cut list panel can only be toggled via main button.');
   }
 
   const viewsRoot = document.getElementById('views');

--- a/styles.css
+++ b/styles.css
@@ -54,20 +54,67 @@ body {
   overflow-y: auto;
 }
 
-#view-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space);
-  align-items: center;
+#cutListPanel[hidden] {
+  display: none;
 }
 
-#view-controls button {
-  padding: calc(var(--space) / 2) calc(var(--space) * 1.25);
+.toolbar {
+  display: flex;
+  gap: calc(var(--space) * 0.75);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pill,
+.seg {
+  padding: calc(var(--space) * 0.5) calc(var(--space) * 1.25);
+  border: 1px solid #bbb;
   border-radius: 999px;
-  border: 1px solid #ccc;
   background: #fff;
   color: #111;
   cursor: pointer;
+  font: inherit;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.seg.active {
+  background: #222;
+  border-color: #222;
+  color: #fff;
+}
+
+.pill:focus-visible,
+.seg:focus-visible {
+  outline: 2px solid #222;
+  outline-offset: 2px;
+}
+
+.pill:hover,
+.seg:hover {
+  border-color: #999;
+}
+
+.pill:active,
+.seg:active {
+  transform: translateY(1px);
+}
+
+#cutListPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space);
+  padding: calc(var(--space) * 1.5);
+  border-radius: 12px;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+}
+
+.cut-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space);
 }
 
 #controlsRoot {
@@ -114,13 +161,6 @@ canvas {
   .views {
     grid-template-columns: 1fr;
     grid-template-rows: repeat(4, minmax(0, 40vh));
-  }
-}
-
-@media (max-width: 480px) {
-  #view-controls {
-    flex-direction: column;
-    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the old view control block with a toolbar that provides segmented view buttons plus Quad⇄3D and Cut List actions
- port toolbar, segmented button, and pill styles while styling the inline cut list panel container
- update the main UI script to sync the active view button, handle Quad⇄3D toggling, and open/close the cut list panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2d28bc2483218278098f28ef82d2