### PR TITLE
Add troubleshooting tip for npm permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ Timber-size can be bundled into a standalone HTML file for easy sharing or offli
 
 The build step bundles the app and writes the output to `dist/app.single.html`.
 
+
+## Troubleshooting
+
+✅ 方法 1：修复 npm 文件夹权限（推荐）
+
+在终端运行：
+
+```bash
+sudo chown -R $(whoami) ~/.npm
+```


### PR DESCRIPTION
## Summary
- add a troubleshooting section documenting how to reset the npm folder permissions when needed

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cee82eb5808321b74173168f3d1f8f