### PR TITLE
Document fin2 as legacy snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Timber-size is a single-file HTML tool for planning timber storage layouts. It g
 ## Getting Started
 
 1. Clone this repository or download the source files.
-2. Open `index.html` in a modern web browser.
+2. Open `index.html` in a modern web browser. This is the supported entry point for the app; `fin2.html` is retained only as a legacy reference snapshot.
 3. Enter your storage pattern and dimensions. The 3D, plan, front, and side views update automatically, and cut lists are generated live.
 4. Run automated checks:
    - Command line: `npm test`
@@ -72,5 +72,5 @@ Timber-size can be bundled into a standalone HTML file for easy sharing or offli
 2. Run the pack script: `npm run pack`
 3. Open the generated `dist/app.single.html` in your browser.
 
-The build step bundles the app and writes the output to `dist/app.single.html`.
+The build step bundles the app (via `pack.mjs`, which targets `index.html`) and writes the output to `dist/app.single.html`, excluding the reference-only `fin2.html`.
 

--- a/fin2.html
+++ b/fin2.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- Legacy/reference snapshot: not used by the current build pipeline. -->
 <html lang="en">
 <head>
 <meta charset="utf-8" />


### PR DESCRIPTION
## Summary
- note in fin2.html that it is a legacy reference snapshot outside the active build
- clarify in the README that index.html is the supported entry point and fin2.html is reference-only
- document that pack.mjs bundles index.html and excludes the reference file

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cef21cf8b4832188b707c110a0f4aa