### PR TITLE
Preserve fractional millimeter parsing

### DIFF
--- a/src/tests/mm.js
+++ b/src/tests/mm.js
@@ -1,5 +1,7 @@
 import {mm} from '../utils/mm.js';
-
 export function testMM(){
-  return [{name:'mm strips suffix', pass:mm('283mm') === 283}];
+  return [
+    {name:'mm strips suffix', pass:mm('283mm') === 283},
+    {name:'mm preserves fractional values', pass:mm('9.5mm') === 9.5}
+  ];
 }

--- a/src/utils/mm.js
+++ b/src/utils/mm.js
@@ -1,5 +1,5 @@
 export const mm = v => {
   const stripped = String(v).replace(/mm$/i, '');
-  const parsed = Number(stripped);
-  return Number.isFinite(parsed) ? Math.ceil(parsed) : 0;
+  const parsed = Number.parseFloat(stripped);
+  return Number.isFinite(parsed) ? parsed : 0;
 };


### PR DESCRIPTION
## Summary
- stop rounding parsed millimeter values so fractional inputs are preserved
- add a unit test to ensure fractional millimeter parsing remains accurate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef2ecbe948321b9d9a19ee0d45558