### PR TITLE
Add supportBatten color mapping

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -3,5 +3,6 @@ export const typeColors = {
   rail: '#b22222',
   bin: '#1e90ff',
   support: '#228b22',
+  supportBatten: '#228b22',
   lintel: '#daa520'
 };


### PR DESCRIPTION
## Summary
- add a color mapping for supportBatten matching support components

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceff727210832183e85f6b7df7ef6a