### PR TITLE
Add bin lip thickness default state value

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -14,7 +14,7 @@ const state = {
   ],
   topClear:10,
   bottomClear:10,
-  bottomRowRails:false,
+  bottomRowRails:false, // default: no base rails (Trofast rule)
   railMode:'edges',
   topSupport:true,
   topOrient:'X',
@@ -30,6 +30,7 @@ const state = {
   binBody:283,
   binFlange:9.5,
   binLip:9,
+  binLipThick:3, // mm; affects rail-to-bin lip relation
   binSlack:6,
   binHeightDefault:95,
   showBins:true,


### PR DESCRIPTION
## Summary
- add a default `binLipThick` value to the shared state to support UI options
- document the default bottom rail behavior and lip thickness units

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceff94aaac83219dabb8f26b16c15a