### PR TITLE
Add height planning defaults and bin profiles

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,10 @@ const state = {
     {height:120,gap:10,overhang:0},
     {height:120,gap:10,overhang:0}
   ],
+  // Height planning (global)
+  openClearTop:10,
+  openSightClear:0,
+  railSafety:3,
   topClear:10,
   bottomClear:10,
   bottomRowRails:false, // default: no base rails (Trofast rule)
@@ -33,6 +37,11 @@ const state = {
   binLip:9,
   binLipThick:9,
   binSlack:6,
+  // Bin height presets (profiles)
+  binHeightProfiles:[
+    {name:'Shallow',height:95},
+    {name:'Deep',height:200}
+  ],
   binHeightDefault:95,
   showBins:true,
   showOverlays:false,


### PR DESCRIPTION
## Summary
- add global defaults for opening clearance and rail safety in the shared state
- introduce reusable bin height profiles alongside the existing default height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d1482622dc832191dc9a62f8d955e4