### PR TITLE
Align rails with bin lip thickness

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -11,12 +11,15 @@ export function buildModel(S) {
   const seg = segments(S);
   const ch = channels(S, seg);
   const levelData = computeLevels(S);
-  const {levels:L, rowOverflow} = levelData;
+  const {levels:L, rowOverflow, rows:rowInfo=[]} = levelData;
   const W = seg.reduce((a,b)=>a+b,0);
   const H = S.autoHeight ? autoHeightFromRows(S, levelData) : S.height;
   const D = S.depth;
   const R = Math.min(S.runnerDepth, S.depth);
   const M = {W,H,D,P,channels:ch,levels:L,rowOverflow,boxes:[]};
+  const rowHeights = rowInfo.map(info => (info && Number.isFinite(info.heightMm)) ? info.heightMm : 0);
+  const lipSource = S.binLipThick != null ? S.binLipThick : S.binLip;
+  const binLip = mm(lipSource);
 
   // Posts (front)
   let x=0; for(const s of seg){ if(s===P) M.boxes.push({type:'post',x,y:0,z:0,w:P,h:H,d:P}); x+=s; }
@@ -50,27 +53,38 @@ export function buildModel(S) {
   if(S.extraBottomBeam) addSupport('bottom', {orient:S.extraBottomOrient, yPos:clamp(H - 2*P - mm(S.extraBottomLift), P, H-2*P)});
 
   // Rails and bins
+  const rowsSource = Array.isArray(S.rows) ? S.rows : [];
   ch.forEach((c)=>{
     const xs=railXPositions(c,S);
-    L.forEach((y,idx)=>{
-      const allowBottom = (idx!==0 || S.bottomRowRails);
-      if(allowBottom) xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y,z:0,w:P,h:P,d:R}));
-      if(S.showBins && allowBottom){
-        const row=S.rows[idx]||{};
+    for(let idx=0; idx<L.length; idx++){
+      const y=L[idx];
+      let rowHeight=rowHeights[idx];
+      if(!Number.isFinite(rowHeight)){
+        const srcRow = rowsSource[idx];
+        const fallbackHeight = srcRow && srcRow.height != null ? srcRow.height : S.binHeightDefault;
+        rowHeight = mm(fallbackHeight);
+      }
+      const yOpenTop = y + rowHeight;
+      const yRailTop = yOpenTop - binLip;
+      const allowRails = (idx!==0 || S.bottomRowRails);
+      if(allowRails){
+        const yRail = yRailTop - P;
+        xs.forEach(bx => M.boxes.push({type:'rail',x:bx,y:yRail,z:0,w:P,h:P,d:R}));
+      }
+      if(S.showBins && allowRails){
+        const row=rowsSource[idx]||{};
         const slack = mm(S.binSlack);
         const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w-2-slack));
         const overall= bodyW + 2*mm(S.binFlange) + slack;
         const bx=c.x + (c.w - overall)/2;
-        const lipSource = S.binLipThick != null ? S.binLipThick : S.binLip;
-        const lip=mm(lipSource);
         const binH=mm(row.height ?? S.binHeightDefault);
         const over=mm(row.overhang ?? 0);
         const gap=mm(row.gap ?? 0);
         const dHere = Math.max(0, D + over); // prevent negative bin depth
-        const yTop = Math.max(0, y + P - lip);
+        const yTop = Math.max(0, y + P - binLip);
         M.boxes.push({type:'bin',x:bx,y:yTop,z:0,w:overall,h:binH,d:dHere,gap});
       }
-    });
+    }
   });
 
   // Bounds


### PR DESCRIPTION
## Summary
- derive per-row heights from computeLevels so rail placement can track bin openings
- place rails at the bin lip underside and continue skipping the lowest row when bottom rails are disabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf0512660883219417e07ba80191f9