### PR TITLE
Adjust bin height selection precedence

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -6,6 +6,16 @@ import {computeLevels} from './utils/computeLevels.js';
 import {railXPositions} from './utils/railXPositions.js';
 import {autoHeightFromRows} from './utils/autoHeight.js';
 
+// 取每列 bin 高度：自訂 -> profile -> 預設
+function binHeightForRow(S, row){
+  if (row && Number.isFinite(row.binHeight) && row.binHeight > 0) return row.binHeight;
+  const idx = Number(row?.binProfileIndex);
+  if (Number.isInteger(idx) && idx >= 0 && Array.isArray(S.binHeightProfiles) && S.binHeightProfiles[idx]){
+    return S.binHeightProfiles[idx].height;
+  }
+  return S.binHeightDefault;
+}
+
 export function buildModel(S) {
   const P = S.post;
   const seg = segments(S);
@@ -63,7 +73,7 @@ export function buildModel(S) {
         const bx=c.x + (c.w - overall)/2;
         const lipSource = S.binLipThick != null ? S.binLipThick : S.binLip;
         const lip=mm(lipSource);
-        const binH=mm(row.height ?? S.binHeightDefault);
+        const binH=mm(binHeightForRow(S, row));
         const over=mm(row.overhang ?? 0);
         const gap=mm(row.gap ?? 0);
         const dHere = Math.max(0, D + over); // prevent negative bin depth


### PR DESCRIPTION
## Summary
- add a helper to choose per-row bin heights using custom values, profiles, or the default
- update bin height calculations to use the helper so bin height is decoupled from row height

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d14857965083219361bc3824eb1a33