### PR TITLE
Add opening planner controls for row targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,31 @@
               <div id="rowsList" class="ctl" style="gap:.5rem"></div>
             </section>
 
+            <!-- Opening planner (height-based) -->
+            <section class="grp" id="grp-opening-planner">
+              <h2>Opening Planner (height)</h2>
+              <div class="row">
+                <div class="ctl" style="width:160px">
+                  <span>Item target height (mm)</span>
+                  <input type="number" id="itemTargetHeight" min="0" step="1" />
+                </div>
+                <div class="ctl" style="width:160px">
+                  <span>Top clearance (mm)</span>
+                  <input type="number" id="openClearTop" min="0" step="1" />
+                </div>
+                <div class="ctl" style="width:160px">
+                  <span>Sight clearance (mm)</span>
+                  <input type="number" id="openSightClear" min="0" step="1" />
+                </div>
+                <!-- optional -->
+                <div class="ctl" style="width:160px">
+                  <span>Rail safety (mm)</span>
+                  <input type="number" id="railSafety" min="0" step="1" />
+                </div>
+              </div>
+              <p class="dim">Target per row = max(Bin height, Item height) + Top clearance + Sight clearance + Rail safety</p>
+            </section>
+
             <!-- MVP: Rails -->
             <section class="grp" id="grp-rails">
               <h2>Rails</h2>


### PR DESCRIPTION
## Summary
- add an Opening Planner section near the row controls with inputs for item target height, top clearance, sight clearance, and optional rail safety
- display the planner hint text explaining the per-row target calculation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d150adc34483219a5b286bdb82c7fe