### PR TITLE
調整 bin 高度來源

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -6,6 +6,16 @@ import {computeLevels} from './utils/computeLevels.js';
 import {railXPositions} from './utils/railXPositions.js';
 import {autoHeightFromRows} from './utils/autoHeight.js';
 
+// 取每列 bin 高度：自訂 -> profile -> 預設
+function binHeightForRow(S, row){
+  if (row && Number.isFinite(row.binHeight) && row.binHeight > 0) return row.binHeight;
+  const idx = Number(row?.binProfileIndex);
+  if (Number.isInteger(idx) && idx >= 0 && Array.isArray(S.binHeightProfiles) && S.binHeightProfiles[idx]){
+    return S.binHeightProfiles[idx].height;
+  }
+  return S.binHeightDefault;
+}
+
 export function buildModel(S) {
   const P = S.post;
   const seg = segments(S);
@@ -77,7 +87,7 @@ export function buildModel(S) {
         const bodyW=Math.min(mm(S.binBody), Math.max(0, c.w-2-slack));
         const overall= bodyW + 2*mm(S.binFlange) + slack;
         const bx=c.x + (c.w - overall)/2;
-        const binH=mm(row.height ?? S.binHeightDefault);
+        const binH=mm( binHeightForRow(S, row) );
         const over=mm(row.overhang ?? 0);
         const gap=mm(row.gap ?? 0);
         const dHere = Math.max(0, D + over); // prevent negative bin depth


### PR DESCRIPTION
## Summary
- 新增 `binHeightForRow` 以依序套用自訂值、profile 與預設值
- 在建立 bin 模型時改用該函式取得高度，避免與列高綁定

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2397822ac832191104880668d5f6a