### PR TITLE
Prevent row planner buttons from submitting the form

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
             <section class="grp" id="grp-columns">
               <h2>Columns &amp; Openings</h2>
               <div class="row">
-                <button id="btnAddCol" class="pill">+ Add Column</button>
-                <button id="btnRemoveCol" class="pill">− Remove Column</button>
+                <button id="btnAddCol" class="pill" type="button">+ Add Column</button>
+                <button id="btnRemoveCol" class="pill" type="button">− Remove Column</button>
               </div>
               <div id="columnsList" class="ctl" style="gap:.5rem"></div>
               <p class="dim">Tip: columns edit writes back to <code>patternText</code>.</p>
@@ -68,8 +68,8 @@
             <section class="grp" id="grp-rows">
               <h2>Rows</h2>
               <div class="row">
-                <button id="btnAddRow" class="pill">+ Add Row</button>
-                <button id="btnRemoveRow" class="pill">− Remove Row</button>
+                <button id="btnAddRow" class="pill" type="button">+ Add Row</button>
+                <button id="btnRemoveRow" class="pill" type="button">− Remove Row</button>
               </div>
               <div id="rowsList" class="ctl" style="gap:.5rem"></div>
             </section>

--- a/src/main.js
+++ b/src/main.js
@@ -198,15 +198,17 @@ function renderRowsUI(state){
     const wrap = document.createElement('div');
     wrap.className = 'row';
     const rowHeight = Math.round(Number(r && r.height) || 0);
+    const sanitizedHeight = Math.max(1, rowHeight);
     const profs = Array.isArray(state.binHeightProfiles) ? state.binHeightProfiles : [];
     const hasCustom = r && Number.isFinite(r.binHeight) && r.binHeight > 0;
     const selValue = hasCustom ? 'custom' : (Number.isInteger(r && r.binProfileIndex) ? String(r.binProfileIndex) : '');
     const target = getTargetHeight(state, r || {});
+    const isTargetApplied = sanitizedHeight === target;
 
     wrap.innerHTML = `
       <div class="ctl" style="width:140px">
         <span>Row height (mm)</span>
-        <input type="number" min="1" step="1" value="${Math.max(1, rowHeight)}" data-row="${i}">
+        <input type="number" min="1" step="1" value="${sanitizedHeight}" data-row="${i}">
       </div>
 
       <div class="ctl" style="width:160px">
@@ -227,7 +229,7 @@ function renderRowsUI(state){
         <span>Target suggestion</span>
         <div class="row">
           <b>${target}</b><span class="dim"> mm</span>
-          <button class="pill" data-apply="${i}">Apply</button>
+          <button class="pill" type="button" data-apply="${i}" ${isTargetApplied ? 'disabled' : ''}>${isTargetApplied ? 'Applied' : 'Apply'}</button>
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary
- stop the column and row planner buttons from triggering form submission by marking them as plain buttons
- disable the per-row target apply button when the height already matches the suggested target

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d23e3040288321b43eef7088856f98