### PR TITLE
Stop canvas clicks from changing view mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -622,12 +622,10 @@ function init() {
     if (canvases.length === 0) {
       console.warn('No canvases found under #views.');
     } else {
-      canvases.forEach(cvs=>{
-        cvs.addEventListener('click', ()=>{
-          const vm = getState().viewMode;
-          setViewMode(vm === 'quad' ? cvs.id : 'quad');
-        });
-      });
+      // Canvas interactions now solely control the renderers (e.g. orbit, pan, zoom).
+      // Layout changes should be triggered via the toolbar controls instead of clicks
+      // directly on the viewports, so we intentionally do not wire up any view-mode
+      // toggling handlers here.
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the canvas click handler that toggled view modes
- rely on toolbar controls for layout changes so viewport interactions never change the active layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b1041ee8832196d6bee8afa3884b