### PR TITLE
Ensure default segments respect post thickness

### DIFF
--- a/src/tests/parser.js
+++ b/src/tests/parser.js
@@ -1,4 +1,5 @@
 import {parseList, normalizeSegments} from '../utils/parse.js';
+import {segments} from '../utils/segments.js';
 
 export function testParser(){
   const p1 = parseList('43mm, 283, 43, junk');
@@ -8,8 +9,14 @@ export function testParser(){
   const p2 = normalizeSegments([43,43,283,43,43], 43);
   const normPass = p2.length === 3 && p2[0]===43 && p2[1]===283 && p2[2]===43;
 
+  const fallbackSegments = segments({patternText:'junk', post:75});
+  const fallbackExpected = [75,283,75,283,75];
+  const fallbackPass = fallbackSegments.length === fallbackExpected.length
+    && fallbackSegments.every((n,i)=>n === fallbackExpected[i]);
+
   return [
     {name:'parseList basic', pass:parsePass},
-    {name:'normalizeSegments dedup', pass:normPass}
+    {name:'normalizeSegments dedup', pass:normPass},
+    {name:'segments fallback honors post', pass:fallbackPass}
   ];
 }

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,4 +1,4 @@
-export function parseList(txt){
+export function parseList(txt, post = 43){
   const re=/\b(\d+(?:\.\d+)?)\s*(?:mm)?\b/gi;
   const out=[]; let m;
   const str=String(txt);
@@ -6,7 +6,19 @@ export function parseList(txt){
     const n=Math.ceil(parseFloat(m[1]));
     if(Number.isFinite(n) && n>0) out.push(n);
   }
-  return out.length ? out : [43,283,43,43,283,43,43];
+  if(out.length) return out;
+
+  const fallbackPostRaw = Math.round(Number(post));
+  const fallbackPost = Number.isFinite(fallbackPostRaw) && fallbackPostRaw > 0 ? fallbackPostRaw : 43;
+  return [
+    fallbackPost,
+    283,
+    fallbackPost,
+    fallbackPost,
+    283,
+    fallbackPost,
+    fallbackPost
+  ];
 }
 
 export function normalizeSegments(arr, post){

--- a/src/utils/segments.js
+++ b/src/utils/segments.js
@@ -1,5 +1,6 @@
 import {parseList, normalizeSegments} from './parse.js';
 
 export function segments(S){
-  return normalizeSegments(parseList(S.patternText), S.post);
+  const post = Number.isFinite(S?.post) ? S.post : 0;
+  return normalizeSegments(parseList(S?.patternText, post), post);
 }


### PR DESCRIPTION
## Summary
- update the list parser fallback to build default segments using the current post thickness
- pass the post size through segments() so the normalizer receives the corrected values
- add a regression test that asserts the fallback honours non-default post widths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3ddd47e1c832180dcc4d108205e4f