### PR TITLE
Add unit test for fitCanvas transform alignment

### DIFF
--- a/src/tests/fit-canvas.js
+++ b/src/tests/fit-canvas.js
@@ -1,0 +1,55 @@
+import {fitCanvas} from '../utils/fit.js';
+
+function arrayEquals(a, b) {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+export function testFitCanvasAlignment() {
+  const transforms = [];
+  const cleared = [];
+  const contextStub = {
+    setTransform: (...args) => transforms.push([...args]),
+    clearRect: (...args) => cleared.push([...args])
+  };
+  const canvas = {
+    clientWidth: 120,
+    clientHeight: 80,
+    width: 0,
+    height: 0,
+    getContext(type) {
+      if (type !== '2d') throw new Error(`Unexpected context type: ${type}`);
+      return contextStub;
+    }
+  };
+
+  const bounds = {min: [10, -5], max: [70, 35]};
+  const ctx = fitCanvas(canvas, bounds);
+
+  const width = bounds.max[0] - bounds.min[0];
+  const height = bounds.max[1] - bounds.min[1];
+  const expectedScale = Math.min(canvas.clientWidth / width, canvas.clientHeight / height);
+  const expectedTransform = [
+    expectedScale,
+    0,
+    0,
+    -expectedScale,
+    -bounds.min[0] * expectedScale,
+    canvas.clientHeight + bounds.min[1] * expectedScale
+  ];
+  const identityTransform = [1, 0, 0, 1, 0, 0];
+
+  const pass =
+    ctx === contextStub &&
+    canvas.width === canvas.clientWidth &&
+    canvas.height === canvas.clientHeight &&
+    transforms.length === 2 &&
+    arrayEquals(transforms[0], identityTransform) &&
+    arrayEquals(transforms[1], expectedTransform) &&
+    cleared.length === 1 &&
+    arrayEquals(cleared[0], [0, 0, canvas.clientWidth, canvas.clientHeight]);
+
+  return [{
+    name: 'fitCanvas applies expected scale and translation',
+    pass
+  }];
+}

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -7,6 +7,7 @@ import {testMM} from './mm.js';
 import {testLevels} from './levels.js';
 import {testPinchZoom} from './pinch-zoom.js';
 import {testBinSlack} from './bin-slack.js';
+import {testFitCanvasAlignment} from './fit-canvas.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
@@ -19,7 +20,8 @@ export function runTests(){
     ...testMM(),
     ...testLevels(),
     ...testPinchZoom(),
-    ...testBinSlack()
+    ...testBinSlack(),
+    ...testFitCanvasAlignment()
   ];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;


### PR DESCRIPTION
## Summary
- add a unit test that stubs a canvas context and verifies fitCanvas applies the expected scale and translation for a known bounding box
- include the new fitCanvas check in the aggregate test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3eb2c3ba48321943e3a595a7434ce