### PR TITLE
Align timber colours with legend palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,15 @@
           <div class="hud">3D</div>
           <button class="fit" id="fit-three" data-fit="three" type="button">Fit view</button>
           <canvas id="three"></canvas>
-          <div class="legend">Posts: pink · Lintels: gray · Rails: blue · Supports: orange · Bins: red</div>
+          <div class="legend">
+            <div class="legend-grid">
+              <div class="legend-item"><span class="legend-swatch legend-post"></span>Posts</div>
+              <div class="legend-item"><span class="legend-swatch legend-lintel"></span>Lintels</div>
+              <div class="legend-item"><span class="legend-swatch legend-rail"></span>Rails</div>
+              <div class="legend-item"><span class="legend-swatch legend-support"></span>Supports</div>
+              <div class="legend-item"><span class="legend-swatch legend-bin"></span>Bins</div>
+            </div>
+          </div>
         </div>
         <div class="view" data-view="plan">
           <div class="hud">TOP / Plan (X×Z)</div>

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,8 +1,8 @@
 export const typeColors = {
-  post: '#8d5524',
-  rail: '#b22222',
-  bin: '#1e90ff',
-  support: '#228b22',
-  supportBatten: '#228b22',
-  lintel: '#daa520'
+  post: '#f472b6', // Posts: vivid pink to spotlight the vertical uprights in 3D views.
+  rail: '#60a5fa', // Rails: cool blue to emphasise the horizontal run along the frame.
+  bin: '#f87171', // Bins: punchy red to differentiate removable storage elements.
+  support: '#fb923c', // Supports: bright orange to highlight diagonal or bracing members.
+  supportBatten: '#fb923c', // Support battens: share the support orange to show they reinforce the same assemblies.
+  lintel: '#9ca3af' // Lintels: neutral gray to convey overhead structural spans.
 };

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,33 @@ body {
   line-height: 1.4;
 }
 
+.legend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.3rem 0.6rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
+}
+
+.legend-swatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  flex-shrink: 0;
+}
+
+.legend-post { background: #f472b6; }
+.legend-lintel { background: #9ca3af; }
+.legend-rail { background: #60a5fa; }
+.legend-support { background: #fb923c; }
+.legend-bin { background: #f87171; }
+
 .panel {
   background: #f7f7f8;
   color: #111;


### PR DESCRIPTION
## Summary
- update the shared type color map so posts, rails, bins, supports, and lintels use the legend's pink, blue, red, orange, and gray hues
- document each timber color entry with inline comments describing its purpose and visual cue
- sync the legend swatch styles with the refreshed palette so the UI and renders match

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d52147a5648321a2d62ae435f8f62d