### PR TITLE
Ensure canvas views resize with the layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -607,6 +607,13 @@ function init() {
     }
   }
 
+  const scheduleResizeRender = ()=>scheduleViewDrawing(render);
+  window.addEventListener('resize', scheduleResizeRender, {passive: true});
+  if(viewsRoot && typeof ResizeObserver === 'function'){
+    const resizeObserver = new ResizeObserver(()=>scheduleResizeRender());
+    resizeObserver.observe(viewsRoot);
+  }
+
   const threeEl = document.getElementById('three');
   if (threeEl) {
     init3dControls(threeEl);

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,7 @@ body {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(280px, 1fr);
   min-height: 100vh;
+  height: 100vh;
   background: #111;
 }
 
@@ -32,6 +33,7 @@ body {
   padding: calc(var(--space) * 2);
   min-width: 0;
   min-height: 0;
+  height: 100%;
 }
 
 .view {
@@ -39,6 +41,15 @@ body {
   background: #000;
   border-radius: 12px;
   overflow: hidden;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.view canvas {
+  flex: 1;
+  width: 100%;
+  height: 100%;
   min-height: 0;
 }
 
@@ -233,6 +244,7 @@ canvas {
   .views {
     grid-template-columns: 1fr;
     grid-template-rows: repeat(4, minmax(0, 40vh));
+    height: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- let the four view panels flex to fill the grid column so each canvas expands with the layout
- keep the stacked mobile layout responsive by releasing the forced height under 768px
- schedule re-renders when the window or view container resizes so drawings stay aligned after UI changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5248eb12c832197af1d20c52ab4d6