### PR TITLE
refactor: centralize type colors

### DIFF
--- a/src/tests/colors.js
+++ b/src/tests/colors.js
@@ -1,0 +1,25 @@
+import {buildModel} from '../model.js';
+import {getState} from '../state.js';
+import {BOX_TYPES, typeColors, getTypeColorLoose} from '../utils/colors.js';
+import {__resetWarnOnce} from '../utils/warnOnce.js';
+
+export function testColors(){
+  const declared = Object.keys(typeColors).sort();
+  const expected = [...BOX_TYPES].sort();
+  const paletteCoverage = JSON.stringify(declared) === JSON.stringify(expected);
+
+  const model = buildModel(getState());
+  const missing = new Set();
+  model.boxes.forEach(box => {
+    const color = getTypeColorLoose(box.type);
+    if (!color) missing.add(box.type);
+  });
+  const allBoxesColored = missing.size === 0;
+
+  __resetWarnOnce();
+
+  return [
+    {name:'palette covers all box types', pass: paletteCoverage},
+    {name:'model boxes resolve to a colour', pass: allBoxesColored}
+  ];
+}

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -10,6 +10,7 @@ import {testBinSlack} from './bin-slack.js';
 import {testBinPlacement} from './bin-placement.js';
 import {testFitCanvasAlignment} from './fit-canvas.js';
 import {testRowSizing} from './row-sizing.js';
+import {testColors} from './colors.js';
 import {fileURLToPath} from 'url';
 
 export function runTests(){
@@ -25,7 +26,8 @@ export function runTests(){
     ...testBinSlack(),
     ...testBinPlacement(),
     ...testFitCanvasAlignment(),
-    ...testRowSizing()
+    ...testRowSizing(),
+    ...testColors()
   ];
   if (typeof console !== 'undefined' && console.table) console.table(results);
   return results;

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,8 +1,48 @@
+import {warnOnce} from './warnOnce.js';
+
+/**
+ * @typedef {'post' | 'lintel' | 'support' | 'rail' | 'bin'} BoxType
+ */
+
+/** @type {readonly BoxType[]} */
+export const BOX_TYPES = Object.freeze(['post', 'lintel', 'support', 'rail', 'bin']);
+
+/**
+ * Canonical color palette for box rendering.
+ * @type {Record<BoxType, string>}
+ */
 export const typeColors = {
   post: '#f472b6', // Posts: vivid pink to spotlight the vertical uprights in 3D views.
+  lintel: '#9ca3af', // Lintels: neutral gray to convey overhead structural spans.
+  support: '#fb923c', // Supports: bright orange to highlight braces and beams.
   rail: '#60a5fa', // Rails: cool blue to emphasise the horizontal run along the frame.
-  bin: '#f87171', // Bins: punchy red to differentiate removable storage elements.
-  support: '#fb923c', // Supports: bright orange to highlight diagonal or bracing members.
-  supportBatten: '#fb923c', // Support battens: share the support orange to show they reinforce the same assemblies.
-  lintel: '#9ca3af' // Lintels: neutral gray to convey overhead structural spans.
+  bin: '#f87171' // Bins: punchy red to differentiate removable storage elements.
 };
+
+/**
+ * Resolve a colour for a known {@link BoxType}.
+ *
+ * @param {BoxType} type
+ * @returns {string}
+ */
+export function getTypeColor(type) {
+  const color = typeColors[type];
+  if (!color) {
+    throw new Error(`Missing color for type: ${type}`);
+  }
+  return color;
+}
+
+/**
+ * Resolve a colour for arbitrary input with telemetry + fallback.
+ *
+ * @param {string} type
+ * @returns {string}
+ */
+export function getTypeColorLoose(type) {
+  if (type in typeColors) {
+    return typeColors[type];
+  }
+  warnOnce(`Missing color for type: ${type}`);
+  return typeColors.post;
+}

--- a/src/utils/warnOnce.js
+++ b/src/utils/warnOnce.js
@@ -1,0 +1,21 @@
+const warned = new Set();
+
+/**
+ * Emit a console warning once per unique message.
+ *
+ * @param {string} message
+ */
+export function warnOnce(message) {
+  if (warned.has(message)) return;
+  warned.add(message);
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(message);
+  }
+}
+
+/**
+ * Test helper to reset the warning cache.
+ */
+export function __resetWarnOnce() {
+  warned.clear();
+}

--- a/src/views/front.js
+++ b/src/views/front.js
@@ -1,18 +1,18 @@
 import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
-import {typeColors} from '../utils/colors.js';
+import {getTypeColor} from '../utils/colors.js';
 
 export function renderFront(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
   const ctx = fitCanvas(canvas, {min:[min[0], min[1]], max:[max[0], max[1]]});
   model.boxes.forEach(box => {
-    const color = typeColors[box.type] || '#fff';
+    const color = getTypeColor(box.type);
     drawRect(ctx, box.x, box.y, box.w, box.h, color);
   });
-    if (overlays) {
-      drawOverlayDimensions(ctx, model.bounds, [
-        {label: 'W', axis: 0},
-        {label: 'H', axis: 1}
-      ]);
-    }
+  if (overlays) {
+    drawOverlayDimensions(ctx, model.bounds, [
+      {label: 'W', axis: 0},
+      {label: 'H', axis: 1}
+    ]);
+  }
 }

--- a/src/views/plan.js
+++ b/src/views/plan.js
@@ -1,12 +1,12 @@
 import {drawRect, drawText, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
-import {typeColors} from '../utils/colors.js';
+import {getTypeColor} from '../utils/colors.js';
 
 export function renderPlan(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
   const ctx = fitCanvas(canvas, {min:[min[0], min[2]], max:[max[0], max[2]]});
   model.boxes.forEach(box => {
-    const color = typeColors[box.type] || '#fff';
+    const color = getTypeColor(box.type);
     drawRect(ctx, box.x, box.z, box.w, box.d, color);
   });
   if (overlays) {

--- a/src/views/side.js
+++ b/src/views/side.js
@@ -1,12 +1,12 @@
 import {drawRect, drawOverlayDimensions} from '../utils/draw2d.js';
 import {fitCanvas} from '../utils/fit.js';
-import {typeColors} from '../utils/colors.js';
+import {getTypeColor} from '../utils/colors.js';
 
 export function renderSide(canvas, model, overlays = false) {
   const {min, max} = model.bounds;
   const ctx = fitCanvas(canvas, {min:[min[2], min[1]], max:[max[2], max[1]]});
   model.boxes.forEach(box => {
-    const color = typeColors[box.type] || '#fff';
+    const color = getTypeColor(box.type);
     drawRect(ctx, box.z, box.y, box.d, box.h, color);
   });
   if (overlays) {

--- a/src/views/view3d.js
+++ b/src/views/view3d.js
@@ -1,4 +1,4 @@
-import {typeColors} from '../utils/colors.js';
+import {getTypeColor} from '../utils/colors.js';
 import {getState, setCamera} from '../state.js';
 import {clamp} from '../utils/math.js';
 
@@ -50,7 +50,7 @@ export function render3d(canvas, model, overlays=false){
 
   const faces=[];
   model.boxes.forEach(b=>{
-    const base=typeColors[b.type]||'#ddd';
+    const base=getTypeColor(b.type);
     makeBoxFaces(b.x,b.y,b.z,b.w,b.h,b.d).forEach(facePts=>{
       const tp=facePts.map(pt=>{
         const p0=[pt[0]-cx, pt[1]-cy, pt[2]-cz];


### PR DESCRIPTION
## Summary
- centralize box type palette with typed helpers and warn-once fallback
- switch all canvas renderers to resolve colors via getTypeColor
- add regression tests to verify palette coverage across generated models

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5277288b483219c21be6cdc93a6ae