### PR TITLE
Clamp invalid post widths to defaults

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ import {renderSide} from './views/side.js';
 import {renderPlan} from './views/plan.js';
 import {render3d, init3dControls, reset3dCamera} from './views/view3d.js';
 import {segments as stateSegments} from './utils/segments.js';
+import {postSize} from './utils/post.js';
 import {
   describeRowSizing,
   parseNonNegativeMmInput,
@@ -102,8 +103,7 @@ function applyColumnWidths(widths){
     .map(v=>Math.round(Number(v)))
     .filter(v=>Number.isFinite(v) && v>0);
   const values = sanitized.length ? sanitized : [DEFAULT_COLUMN_WIDTH];
-  const postRaw = Math.round(Number(state.post));
-  const post = Number.isFinite(postRaw) && postRaw>0 ? postRaw : 1;
+  const post = Math.round(postSize(state));
   const seg = [post];
   values.forEach(w=>{
     seg.push(w);
@@ -494,7 +494,7 @@ function init() {
 
   const postInput = document.getElementById('post-input');
   if (postInput) {
-    postInput.value = s.post;
+    postInput.value = postSize(s);
     postInput.addEventListener('input', e=>setPost(e.target.value));
   } else {
     console.warn('#post-input not found. Skipping post input setup.');

--- a/src/model.js
+++ b/src/model.js
@@ -6,9 +6,10 @@ import {computeLevels} from './utils/computeLevels.js';
 import {railXPositions} from './utils/railXPositions.js';
 import {autoHeightFromRows} from './utils/autoHeight.js';
 import {resolveBinHeightMm} from './utils/rowSizing.js';
+import {postSize} from './utils/post.js';
 
 export function buildModel(S) {
-  const P = S.post;
+  const P = postSize(S);
   const seg = segments(S);
   const ch = channels(S, seg);
   const levelData = computeLevels(S);

--- a/src/state.js
+++ b/src/state.js
@@ -84,7 +84,8 @@ export function setDepth(value){
 }
 
 export function setPost(value){
-  state.post = parseNumber(value, 0);
+  const raw = parseNumber(value, 0);
+  state.post = raw > 0 ? raw : DEFAULT_POST_MM;
   notify();
 }
 

--- a/src/tests/state-setters.js
+++ b/src/tests/state-setters.js
@@ -12,6 +12,7 @@ import {
   setBinLipThickness,
   toggleRearFrame
 } from '../state.js';
+import {DEFAULT_POST_MM} from '../config/defaults.js';
 
 export function testStateSetters(){
   const base = JSON.parse(JSON.stringify(getState()));
@@ -28,9 +29,9 @@ export function testStateSetters(){
   const depthNaN = getState().depth === 0;
 
   setPost(-1);
-  const postNeg = getState().post === 0;
+  const postNeg = getState().post === DEFAULT_POST_MM;
   setPost('bar');
-  const postNaN = getState().post === 0;
+  const postNaN = getState().post === DEFAULT_POST_MM;
 
   setCamera({yaw:-1, pitch:-0.5});
   const camNeg = getState().yaw === -1 && getState().pitch === -0.5;
@@ -50,8 +51,8 @@ export function testStateSetters(){
     {name:'height NaN clamps to 0', pass:heightNaN},
     {name:'depth negative clamps to 0', pass:depthNeg},
     {name:'depth NaN clamps to 0', pass:depthNaN},
-    {name:'post negative clamps to 0', pass:postNeg},
-    {name:'post NaN clamps to 0', pass:postNaN},
+    {name:'post negative resets to default', pass:postNeg},
+    {name:'post NaN resets to default', pass:postNaN},
     {name:'camera allows negative yaw/pitch', pass:camNeg},
     {name:'camera ignores invalid yaw/pitch', pass:camNaN}
   );

--- a/src/utils/autoHeight.js
+++ b/src/utils/autoHeight.js
@@ -1,5 +1,6 @@
 import {mm} from './mm.js';
 import {computeLevels} from './computeLevels.js';
+import {postSize} from './post.js';
 
 export function autoHeightFromRows(S, shared){
   const computed = shared ?? computeLevels(S);
@@ -10,7 +11,7 @@ export function autoHeightFromRows(S, shared){
     heights += row.heightMm ?? 0;
     gaps += row.gapMm ?? 0;
   }
-  const P = S.post;
+  const P = postSize(S);
   const lintels = P * ((rows.length || S.rows.length) + 1);
   const bottomClear = computed.bottomClearMm ?? mm(S.bottomClear);
   const topClear = mm(S.topClear);

--- a/src/utils/channels.js
+++ b/src/utils/channels.js
@@ -1,7 +1,8 @@
 import {segments} from './segments.js';
+import {postSize} from './post.js';
 
 export function channels(S, seg = segments(S)){
-  const P=S.post; let x=0; const out=[];
+  const P=postSize(S); let x=0; const out=[];
   for(const s of seg){
     if(s!==P) out.push({x, w:s});
     x += s;

--- a/src/utils/computeLevels.js
+++ b/src/utils/computeLevels.js
@@ -1,8 +1,9 @@
 import {mm} from './mm.js';
 import {clamp} from './math.js';
+import {postSize} from './post.js';
 
 export function computeLevels(S){
-  const P = S.post;
+  const P = postSize(S);
   const bottomClearMm = mm(S.bottomClear);
   let y = P + bottomClearMm;
   const maxLevel = (S.autoHeight ? 1e9 : S.height) - P;

--- a/src/utils/post.js
+++ b/src/utils/post.js
@@ -1,0 +1,6 @@
+import {DEFAULT_POST_MM} from '../config/defaults.js';
+
+export function postSize(source){
+  const raw = Number(source?.post);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_POST_MM;
+}

--- a/src/utils/railXPositions.js
+++ b/src/utils/railXPositions.js
@@ -1,4 +1,7 @@
+import {postSize} from './post.js';
+
 export function railXPositions(ch, S){
-  if(S.railMode === 'centered') return [ch.x + (ch.w - S.post)/2];
-  return [ch.x, ch.x + ch.w - S.post];
+  const post = postSize(S);
+  if(S.railMode === 'centered') return [ch.x + (ch.w - post)/2];
+  return [ch.x, ch.x + ch.w - post];
 }

--- a/src/utils/segments.js
+++ b/src/utils/segments.js
@@ -1,6 +1,7 @@
 import {parseList, normalizeSegments} from './parse.js';
+import {postSize} from './post.js';
 
 export function segments(S){
-  const post = Number.isFinite(S?.post) ? S.post : 0;
+  const post = postSize(S);
   return normalizeSegments(parseList(S?.patternText, post), post);
 }


### PR DESCRIPTION
## Summary
- reset the post width to the default when users supply non-positive values
- use a shared helper to derive the effective post size across model, layout, and UI code
- update tests to reflect the defaulting behavior and ensure UI inputs show the sanitized value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d96027946c832193b14ef47d00cf6f