### PR TITLE
Add bottom clearance control and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
                 <button id="btnAddRow" class="pill" type="button">+ Add Row</button>
                 <button id="btnRemoveRow" class="pill" type="button">− Remove Row</button>
               </div>
+              <div class="ctl" style="width:160px">
+                <span>Bottom clearance (mm)</span>
+                <input type="number" id="bottomClear" min="0" step="1" />
+              </div>
               <div id="rowsList" class="ctl" style="gap:.5rem"></div>
             </section>
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,8 @@ import {
   setItemTargetHeight,
   setOpenClearTop,
   setOpenSightClear,
-  setRailSafety
+  setRailSafety,
+  setBottomClear
 } from './state.js';
 import {buildModel} from './model.js';
 import {renderFront} from './views/front.js';
@@ -321,6 +322,12 @@ function renderRowsUI(state){
     };
   }
 
+  const bottomClear = document.getElementById('bottomClear');
+  if (bottomClear){
+    const {bottomClearMm} = clearances;
+    if (bottomClear.value !== String(bottomClearMm)) bottomClear.value = bottomClearMm;
+  }
+
   const add = document.getElementById('btnAddRow');
   if (add) add.onclick = ()=>addRow();
   const rm = document.getElementById('btnRemoveRow');
@@ -530,6 +537,18 @@ function init() {
     overlayToggle.addEventListener('change', e=>toggleOverlays(e.target.checked));
   } else {
     console.warn('#overlay-toggle not found. Skipping overlay toggle setup.');
+  }
+
+  const bottomClearInput = document.getElementById('bottomClear');
+  if (bottomClearInput) {
+    bottomClearInput.value = s.bottomClear;
+    bottomClearInput.addEventListener('input', ()=>{
+      const parsed = parseNonNegativeMmInput(bottomClearInput.value);
+      if(parsed == null) return;
+      setBottomClear(parsed);
+    });
+  } else {
+    console.warn('#bottomClear not found. Skipping bottom clearance input setup.');
   }
 
   const viewButtons = document.querySelectorAll('.toolbar .seg[data-view]');

--- a/src/state.js
+++ b/src/state.js
@@ -88,6 +88,14 @@ export function setPost(value){
   notify();
 }
 
+export function setBottomClear(value){
+  const parsed = parseNumber(value, 0);
+  const next = Math.max(0, Math.round(parsed));
+  if(state.bottomClear === next) return;
+  state.bottomClear = next;
+  notify();
+}
+
 export function setPatternText(value){
   state.patternText = value;
   notify();

--- a/src/tests/levels.js
+++ b/src/tests/levels.js
@@ -5,9 +5,14 @@ export function testLevels(){
   const base = getState();
   const S = {...base, autoHeight:false, height:300};
   const M = buildModel(S);
+  const bottomClearTestValue = 50;
+  const withBottomClear = buildModel({...base, autoHeight:true, bottomClear:bottomClearTestValue});
   return [{
     name:'row overflow stops extra levels',
     pass:M.rowOverflow && M.levels.length === 1
+  },{
+    name:'bottom clearance offsets first level',
+    pass:Array.isArray(withBottomClear.levels) && withBottomClear.levels[0] === base.post + bottomClearTestValue
   }];
 }
 

--- a/src/tests/state-setters.js
+++ b/src/tests/state-setters.js
@@ -10,7 +10,8 @@ import {
   setBottomRowRails,
   setRailMode,
   setBinLipThickness,
-  toggleRearFrame
+  toggleRearFrame,
+  setBottomClear
 } from '../state.js';
 
 export function testStateSetters(){
@@ -37,6 +38,13 @@ export function testStateSetters(){
   setCamera({yaw:'a', pitch:'b'});
   const camNaN = getState().yaw === -1 && getState().pitch === -0.5;
 
+  const bottomClearStart = getState().bottomClear;
+  setBottomClear(-20);
+  const bottomClearClamps = getState().bottomClear === 0;
+  setBottomClear('17.6');
+  const bottomClearRounds = getState().bottomClear === 18;
+  setBottomClear(bottomClearStart);
+
   // restore original state
   setHeight(base.height);
   setDepth(base.depth);
@@ -53,7 +61,8 @@ export function testStateSetters(){
     {name:'post negative clamps to 0', pass:postNeg},
     {name:'post NaN clamps to 0', pass:postNaN},
     {name:'camera allows negative yaw/pitch', pass:camNeg},
-    {name:'camera ignores invalid yaw/pitch', pass:camNaN}
+    {name:'camera ignores invalid yaw/pitch', pass:camNaN},
+    {name:'setBottomClear clamps to non-negative integer', pass:bottomClearClamps && bottomClearRounds}
   );
 
   const baseRow = {...base.rows[1]};

--- a/src/utils/rowSizing.js
+++ b/src/utils/rowSizing.js
@@ -60,7 +60,8 @@ export function resolveClearancesMm(state){
     itemTargetMm: nonNegativeRound(mm(state.itemTargetHeight)),
     openClearTopMm: nonNegativeRound(mm(state.openClearTop)),
     openSightClearMm: nonNegativeRound(mm(state.openSightClear)),
-    railSafetyMm: nonNegativeRound(mm(state.railSafety))
+    railSafetyMm: nonNegativeRound(mm(state.railSafety)),
+    bottomClearMm: nonNegativeRound(mm(state.bottomClear))
   };
 }
 


### PR DESCRIPTION
## Summary
- add a bottom-clearance input next to the row controls and keep it in sync with state
- expose a `setBottomClear` state setter and use it when wiring the UI and render helpers
- extend automated tests to cover the bottom-clearance setter and model offset

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e16ee1a0d48321b6c322c5fe6f367e