### PR TITLE
Improve layout controls panel styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,13 +57,60 @@
         </div>
         <div id="controlsRoot">
           <form id="controls">
-            <label>Height <input id="height-input" type="number" /></label>
-            <label>Depth <input id="depth-input" type="number" /></label>
-            <label>Post <input id="post-input" type="number" /></label>
-            <label>Pattern <input id="pattern-input" type="text" /></label>
-            <label><input id="rearFrame-toggle" type="checkbox" /> Rear Frame</label>
-            <label><input id="showBins-toggle" type="checkbox" /> Show Bins</label>
-            <label><input id="overlay-toggle" type="checkbox" /> Overlays</label>
+            <section class="grp grp-basics">
+              <h2>Layout Basics</h2>
+              <p class="dim">Set the foundational dimensions and rail pattern for the system.</p>
+              <div class="field-grid">
+                <label class="field">
+                  <span class="field-title">Height</span>
+                  <span class="field-hint">Overall frame height (mm)</span>
+                  <input id="height-input" type="number" />
+                </label>
+                <label class="field">
+                  <span class="field-title">Depth</span>
+                  <span class="field-hint">Total projection from the wall (mm)</span>
+                  <input id="depth-input" type="number" />
+                </label>
+                <label class="field">
+                  <span class="field-title">Post width</span>
+                  <span class="field-hint">Face width of each support post (mm)</span>
+                  <input id="post-input" type="number" />
+                </label>
+                <label class="field field-wide">
+                  <span class="field-title">Pattern</span>
+                  <span class="field-hint">Column widths separated by commas, e.g. <code>900,600</code></span>
+                  <input id="pattern-input" type="text" />
+                </label>
+              </div>
+            </section>
+
+            <section class="grp grp-display">
+              <h2>Display &amp; Overlays</h2>
+              <p class="dim">Toggle helper views to focus on structure, bins, or planning overlays.</p>
+              <div class="toggle-grid">
+                <label class="toggle">
+                  <input id="rearFrame-toggle" type="checkbox" />
+                  <div class="toggle-body">
+                    <span class="toggle-title">Rear frame</span>
+                    <span class="toggle-hint">Include rear uprights for added rigidity.</span>
+                  </div>
+                </label>
+                <label class="toggle">
+                  <input id="showBins-toggle" type="checkbox" />
+                  <div class="toggle-body">
+                    <span class="toggle-title">Show bins</span>
+                    <span class="toggle-hint">Preview bins inside each planned opening.</span>
+                  </div>
+                </label>
+                <label class="toggle">
+                  <input id="overlay-toggle" type="checkbox" />
+                  <div class="toggle-body">
+                    <span class="toggle-title">Overlays</span>
+                    <span class="toggle-hint">Highlight clearances and target heights.</span>
+                  </div>
+                </label>
+              </div>
+            </section>
 
             <!-- MVP: Columns -->
             <section class="grp" id="grp-columns">

--- a/styles.css
+++ b/styles.css
@@ -244,7 +244,7 @@ body {
 
 #controls {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: calc(var(--space) * 1.5);
   padding: calc(var(--space) * 2);
   border-radius: 20px;
@@ -254,18 +254,92 @@ body {
   box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
 }
 
-#controls label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+#controls > .grp {
+  grid-column: 1 / -1;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: calc(var(--space) * 1.5);
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+  padding: calc(var(--space) * 1.25);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(241, 245, 249, 0.9), rgba(241, 245, 249, 0.4));
+  color: #0f172a;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.field input {
+  width: 100%;
+}
+
+.field-title {
+  font-weight: 600;
   font-size: 0.95rem;
+}
+
+.field-hint {
+  font-size: 0.85rem;
   color: var(--text-muted);
 }
 
-#controls label > span,
-#controls label > strong {
-  font-weight: 600;
+.field-wide {
+  grid-column: 1 / -1;
+}
+
+.toggle-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: calc(var(--space) * 1);
+}
+
+.toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: calc(var(--space) * 1.25);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: linear-gradient(160deg, rgba(241, 245, 249, 0.9), rgba(241, 245, 249, 0.4));
   color: #0f172a;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.toggle:hover {
+  border-color: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 4px 16px rgba(37, 99, 235, 0.1);
+}
+
+.toggle:active {
+  transform: translateY(1px);
+}
+
+.toggle input {
+  margin-top: 0.2rem;
+}
+
+.toggle-body {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.toggle-title {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.toggle-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 input[type="number"],


### PR DESCRIPTION
## Summary
- reorganize the primary layout inputs into dedicated Layout Basics and Display & Overlays groupings with helper copy
- style the new field and toggle cards to provide clearer hierarchy and breathing room around controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1948db12483219f835f0498f54828