### PR TITLE
Prevent supports from intruding into lintel clearance

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -41,9 +41,15 @@ export function buildModel(S) {
     const on = opts.on ?? (where==='top'? S.topSupport : S.bottomSupport); if(!on) return;
     const orient= opts.orient ?? (where==='top'? S.topOrient : S.bottomOrient);
     const size  = opts.size  ?? (where==='top'? mm(S.topSize) : mm(S.bottomSize));
+    const usable = H - 2*P;
+    if (usable < P) return;
     const yPos  = opts.yPos  ?? (where==='top'
-      ? clamp(P + mm(S.topDrop), P, H-2*P)
-      : clamp(H - 2*P - mm(S.bottomLift), P, H-2*P));
+      ? clamp(P + mm(S.topDrop), P, usable)
+      : clamp(usable - mm(S.bottomLift), P, usable));
+    if (yPos + P > H - P) {
+      console.assert(false, 'Support intrudes into lintel space');
+      return;
+    }
     if(orient==='X'){
       const zMid=(D-size)/2; M.boxes.push({type:'support',x:0,y:yPos,z:zMid,w:W,h:P,d:size});
     }else{

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -2,7 +2,7 @@ import {testParser} from './parser.js';
 import {testClamp} from './clamp.js';
 import {testCounts} from './counts.js';
 import {testStateSetters} from './state-setters.js';
-import {testExtraSupport} from './supports.js';
+import {testExtraSupport, testSupportClearance} from './supports.js';
 import {testMM} from './mm.js';
 import {testLevels} from './levels.js';
 import {testPinchZoom} from './pinch-zoom.js';
@@ -20,6 +20,7 @@ export function runTests(){
     ...testCounts(),
     ...testStateSetters(),
     ...testExtraSupport(),
+    ...testSupportClearance(),
     ...testMM(),
     ...testLevels(),
     ...testPinchZoom(),

--- a/src/tests/supports.js
+++ b/src/tests/supports.js
@@ -15,3 +15,22 @@ export function testExtraSupport(){
     {name:'extra bottom beam lift configurable', pass: lifts}
   ];
 }
+
+export function testSupportClearance(){
+  const S = {
+    ...getState(),
+    autoHeight:false,
+    height:100,
+    post:43,
+    topSupport:true,
+    bottomSupport:true,
+    topDrop:0,
+    bottomLift:0
+  };
+  const M = buildModel(S);
+  const supports = M.boxes.filter(b=>b.type==='support');
+  const none = supports.length === 0;
+  return [
+    {name:'supports omitted when height below 3x post', pass: none}
+  ];
+}


### PR DESCRIPTION
## Summary
- skip adding supports when the lintel-to-lintel clearance is thinner than a post and assert their placement stays out of the lintel volume
- add a regression test ensuring no supports are emitted when the cabinet height is less than three times the post size
- register the new support clearance test with the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1a265fc188321ac9496f2ff142bd2