### PR TITLE
Support comma thousands separators in pattern parsing

### DIFF
--- a/src/tests/parser.js
+++ b/src/tests/parser.js
@@ -7,6 +7,11 @@ export function testParser(){
   const p1 = parseList(sampleText);
   const exp1 = [DEFAULT_POST_MM, DEFAULT_OPENING_MM, DEFAULT_POST_MM];
   const parsePass = exp1.every((n,i) => p1[i] === n);
+  const pThousands = parseList('1,200mm, 650, 1,200');
+  const thousandsPass = pThousands.length === 3
+    && pThousands[0] === 1200
+    && pThousands[1] === 650
+    && pThousands[2] === 1200;
 
   const p2 = normalizeSegments([
     DEFAULT_POST_MM,
@@ -27,6 +32,7 @@ export function testParser(){
 
   return [
     {name:'parseList basic', pass:parsePass},
+    {name:'parseList handles thousands separators', pass:thousandsPass},
     {name:'normalizeSegments dedup', pass:normPass},
     {name:'segments fallback honors post', pass:fallbackPass}
   ];

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,11 +1,12 @@
 import {DEFAULT_POST_MM, DEFAULT_OPENING_MM} from '../config/defaults.js';
 
 export function parseList(txt, post = DEFAULT_POST_MM){
-  const re=/\b(\d+(?:\.\d+)?)\s*(?:mm)?\b/gi;
+  const re=/\b(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?)\s*(?:mm)?\b/gi;
   const out=[]; let m;
   const str=String(txt);
   while((m=re.exec(str))){
-    const n=Math.ceil(parseFloat(m[1]));
+    const numeric = m[1].replaceAll(',', '');
+    const n=Math.ceil(parseFloat(numeric));
     if(Number.isFinite(n) && n>0) out.push(n);
   }
   if(out.length) return out;


### PR DESCRIPTION
### Motivation
- Allow the pattern parser to accept human-friendly numbers like `1,200mm` without splitting them into multiple tokens.

### Description
- Update `parseList` in `src/utils/parse.js` to match comma-grouped numbers and strip commas before converting to a numeric value, while preserving existing `mm` and decimal parsing behavior, and add a regression test in `src/tests/parser.js` that asserts `parseList('1,200mm, 650, 1,200')` yields `[1200, 650, 1200]`.

### Testing
- Ran `npm test` and all tests passed, including the new parser test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7fc7259c83218f74c1b2e17af91c)